### PR TITLE
Fix ESLint ignore paths

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "lint": "eslint --ext .js --max-warnings 5 ./",
+    "lint": "eslint --ext .js --max-warnings 5 --ignore-path ../../.eslintignore ./",
     "test": "yarn lint"
   },
   "dependencies": {

--- a/tenants/all/package.json
+++ b/tenants/all/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "basecms-newsletters dev index.js",
     "compile": "basecms-marko-compile compile --dir ./ --silent true",
-    "lint": "eslint --ext .js --max-warnings 5 ./",
+    "lint": "eslint --ext .js --max-warnings 5 --ignore-path ../../.eslintignore ./",
     "test": "yarn lint && yarn compile"
   },
   "dependencies": {


### PR DESCRIPTION
Will now properly ignore generated marko files.