### PR TITLE
AF May2021 newsletter updates 1

### DIFF
--- a/tenants/all/templates/blp-digital-edition.marko
+++ b/tenants/all/templates/blp-digital-edition.marko
@@ -26,7 +26,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       name=newsletter.name
       href=website.get("origin")
       date=date
-      image-src="/files/base/allured/all/image/static/newsletter/blp-digital-edition-header.png"
+      image-src="/files/base/allured/all/image/static/newsletter/blp-2021-digital-edition-header.png"
     />
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">

--- a/tenants/all/templates/blp-newsletter.marko
+++ b/tenants/all/templates/blp-newsletter.marko
@@ -28,7 +28,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/blp-newsletter-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/blp-2021-newsletter-header.png"
       />
 
       <!-- Headline -->

--- a/tenants/all/templates/blp-product-roundup.marko
+++ b/tenants/all/templates/blp-product-roundup.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/blp-product-roundup-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/blp-2021-product-roundup-header.png"
       />
 
       <!-- Headline -->

--- a/tenants/all/templates/components/partnerships-footer.marko
+++ b/tenants/all/templates/components/partnerships-footer.marko
@@ -1,0 +1,27 @@
+$ const logoStyles = {
+  "max-width": "90% !important",
+  "width": "auto !important",
+  "max-height": "80px",
+  "height": "auto !important",
+  "display": "inline-block",
+  "margin": "0 auto",
+  "border": 0,
+  "outline": "none",
+  "text-decoration": "none",
+  "background-color": "#fff",
+};
+
+<common-spacer-element style={ "line-height": "15px", "height": "15px" } />
+
+<div style="background-color: #fff;margin: 0px auto;font-family: arial;width: 100%;max-width: 600px;padding-top:10px; border-top: 1px solid #ddd;" id="partnershipsFooter">
+    <common-spacer-element />
+    <!--[if (gte mso 9)|(lte IE 9)]><table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse;" class="ieTableFix"><tr><td valign="middle" width="250" align="center" style="text-align:center;"><![endif]-->
+    <h3 style="margin: 0px;color: #666;font-size: 16px;line-height: 25px;padding: 0px 5px;background-color: #FFF;text-align: center;text-transform:uppercase;font-weight:normal;font-family:Helvetica,Arial,sans-serif;">${input.sectionName}</h3>
+	<p style="margin:0px;padding:0px;font-family:sans-serif;text-align:center;color: #333;">
+        <marko-newsletter-imgix src=input.imageSrc options={ h: 80 } alt=input.name attrs={ border: 0, height: 80, style: logoStyles }>
+          <@link href=input.href title=input.name target="_blank" />
+        </marko-newsletter-imgix>
+    </p>
+    <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+    <common-spacer-element style={ "line-height": "7px", "height": "7px" } />
+ </div>

--- a/tenants/all/templates/ds-digital-edition.marko
+++ b/tenants/all/templates/ds-digital-edition.marko
@@ -26,7 +26,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       name=newsletter.name
       href=website.get("origin")
       date=date
-      image-src="/files/base/allured/all/image/static/newsletter/ds-digital-edition-header.png"
+      image-src="/files/base/allured/all/image/static/newsletter/ds-2021-digital-edition-header.png"
     />
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -28,7 +28,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ds-newsletter-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/ds-2021-newsletter-header.png"
       />
 
       <!-- Headline -->

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -149,6 +149,14 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         dpm={ position: 4 }
       />
 
+      <!-- partnerships -->
+      <partnerships-footer
+        section-name="Partnerships"
+        name="Partnered With Green Spa Network"
+        href="https://gsnplanet.org/"
+        image-src="/files/base/allured/all/image/static/gsn_logo.png"
+      />
+
       <!-- footer -->
       <daily-footer />
 

--- a/tenants/all/templates/ds-product-roundup.marko
+++ b/tenants/all/templates/ds-product-roundup.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ds-product-roundup-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/ds-2021-product-roundup-header.png"
       />
 
       <!-- Headline -->

--- a/tenants/all/templates/me-digital-edition.marko
+++ b/tenants/all/templates/me-digital-edition.marko
@@ -26,7 +26,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       name=newsletter.name
       href=website.get("origin")
       date=date
-      image-src="/files/base/allured/all/image/static/newsletter/me-digital-edition-header.png"
+      image-src="/files/base/allured/all/image/static/newsletter/me-2021-digital-edition-header.png"
     />
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">

--- a/tenants/all/templates/me-newsletter.marko
+++ b/tenants/all/templates/me-newsletter.marko
@@ -28,7 +28,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/me-newsletter-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/me-2021-newsletter-header.png"
       />
 
       <!-- Headline -->

--- a/tenants/all/templates/me-product-roundup.marko
+++ b/tenants/all/templates/me-product-roundup.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/me-product-roundup-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/me-2021-product-roundup-header.png"
       />
 
       <!-- Headline -->

--- a/tenants/all/templates/np-digital-edition.marko
+++ b/tenants/all/templates/np-digital-edition.marko
@@ -26,7 +26,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       name=newsletter.name
       href=website.get("origin")
       date=date
-      image-src="/files/base/allured/all/image/static/newsletter/np-digital-edition-header.png"
+      image-src="/files/base/allured/all/image/static/newsletter/np-2021-digital-edition-header.png"
     />
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">

--- a/tenants/all/templates/np-newsletter.marko
+++ b/tenants/all/templates/np-newsletter.marko
@@ -28,7 +28,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/np-newsletter-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/np-2021-newsletter-header.png"
       />
 
       <!-- Headline -->

--- a/tenants/all/templates/np-product-roundup.marko
+++ b/tenants/all/templates/np-product-roundup.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/np-product-roundup-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/np-2021-product-roundup-header.png"
       />
 
       <!-- Headline -->


### PR DESCRIPTION
This provides the option for email templates to include a 'Partnerships' or 'Sponsored By' section with a linked logo. This could be expanded to include more than one logo in the future. This should be available for all email templates, so it can be utilized on the SI templates currently being built. I am also adding this feature to the daily Dayspa newsletter template, just above the opt-out footer for our GSN partnership. 
Secondly I have updated the logos and file paths for all 3 newsletter types on the 4 CA brands to use the updated color logos that include taglines. The header images have already been uploaded to S3, so they should start working immediately once merged. 

@solocommand @brandonbk 

Including a preview of the Dayspa daily newsletter to show the updated logo and the partnerships footer at the bottom:
![Example-newHeader-PartnershipFooter](https://user-images.githubusercontent.com/106970/117857309-3b7c5b00-b252-11eb-950a-763bc6015d30.png)
