### PR TITLE
Correct name of “New Products” section.

### DIFF
--- a/tenants/all/templates/si-special-edition.marko
+++ b/tenants/all/templates/si-special-edition.marko
@@ -81,7 +81,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       <daily-block-standard
         date=date
         newsletter=newsletter
-        section-name="Formulating"
+        section-name="New Products"
         dpm={ startingPosition: 300 }
       />
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46794001/125837464-5cf93fab-082b-4f08-a17e-86ced454d08f.png)


Corrects error encountered here