### PR TITLE
[DPP-4649] Updating Dayspa Newsletters to use WellSpa 360 logos

### DIFF
--- a/tenants/all/templates/ds-digital-edition.marko
+++ b/tenants/all/templates/ds-digital-edition.marko
@@ -23,7 +23,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
 
     <!-- View online, logos, dateline -->
     <daily-header
-      name="WellSpa 360 Digital Magazine"
+      name=newsletter.name
       href=website.get("origin")
       date=date
       image-src="/files/base/allured/all/image/static/newsletter/ws-digital-edition-header.png"

--- a/tenants/all/templates/ds-digital-edition.marko
+++ b/tenants/all/templates/ds-digital-edition.marko
@@ -23,10 +23,10 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
 
     <!-- View online, logos, dateline -->
     <daily-header
-      name=newsletter.name
+      name="WellSpa 360 Digital Magazine"
       href=website.get("origin")
       date=date
-      image-src="/files/base/allured/all/image/static/newsletter/ds-2021-digital-edition-header.png"
+      image-src="/files/base/allured/all/image/static/newsletter/ws-digital-edition-header.png"
     />
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -25,7 +25,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
 
       <!-- View online, logos, dateline -->
       <daily-header
-        name="WellSpa 360 Daily Newsletter"
+        name=newsletter.name
         href=website.get("origin")
         date=date
         image-src="/files/base/allured/all/image/static/newsletter/ws-newsletter-header.png"

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -25,10 +25,10 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
 
       <!-- View online, logos, dateline -->
       <daily-header
-        name=newsletter.name
+        name="WellSpa 360 Daily Newsletter"
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ds-2021-newsletter-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/ws-newsletter-header.png"
       />
 
       <!-- Headline -->

--- a/tenants/all/templates/ds-product-roundup.marko
+++ b/tenants/all/templates/ds-product-roundup.marko
@@ -21,10 +21,10 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
 
       <!-- View online, logos, dateline -->
       <daily-header
-        name=newsletter.name
+        name="WellSpa 360 Product Roundup"
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ds-2021-product-roundup-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/ws-product-roundup-header.png"
       />
 
       <!-- Headline -->

--- a/tenants/all/templates/ds-product-roundup.marko
+++ b/tenants/all/templates/ds-product-roundup.marko
@@ -21,7 +21,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
 
       <!-- View online, logos, dateline -->
       <daily-header
-        name="WellSpa 360 Product Roundup"
+        name=newsletter.name
         href=website.get("origin")
         date=date
         image-src="/files/base/allured/all/image/static/newsletter/ws-product-roundup-header.png"


### PR DESCRIPTION
Also hard-coding the names for the header image alt text until we can change the newsletter names in the system.
I am assuming for now that we are just making the Dayspa newsletters appear as the WellSpa 360 newsletters. But I think we would need to address the newsletter names in the system eventually, so the editors aren't scheduling content to the "Dayspa" newsletters after we have switched everything else. 
I'm leaving this as a draft PR in case this is something I have access to change and can be incorporated into this PR. Also the urls will need to switch over, but if we are going to re-route all traffic at launch, it shouldn't be a problem. Again, Not sure if that is something I can address here or not. 
Please let me know if there is anything else you need. Ideally this would go live Monday afternoon with the website switch over so the Tuesday Newsletters would be the first WellSpa 360 ones to be sent out. 
cc: @solocommand 