### PR TITLE
Allow image to be shown for ct-pm formulating block

### DIFF
--- a/tenants/all/templates/ct-newsletter-pm.marko
+++ b/tenants/all/templates/ct-newsletter-pm.marko
@@ -82,7 +82,6 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="Formulating"
-        with-hero=false
         dpm={ startingPosition: 300 }
       />
 


### PR DESCRIPTION
<img width="664" alt="Screen Shot 2021-11-16 at 10 52 23 AM" src="https://user-images.githubusercontent.com/64623209/142029563-463ddd7f-84a5-4ff4-baf5-96f643cc58d5.png">
