### PR TITLE
Set html=true to all obj-text elements without it.

### DIFF
--- a/tenants/all/templates/components/daily-block-grid.marko
+++ b/tenants/all/templates/components/daily-block-grid.marko
@@ -100,7 +100,7 @@ $ const headlineLinkStyle = {
                                 </marko-core-obj-value>
                                 <!--[if gte mso 9]></td></tr></table><![endif]-->
 
-                                <marko-core-obj-text obj=node tag="h2" field="name" attrs={ style: headlineStyle } >
+                                <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } >
                                   <@link href=node.siteContext.url target="_blank" attrs={ style: headlineLinkStyle }>
                                     <@after>
                                       <common-dpm-content node=node dpm={ position: nodePosition } />

--- a/tenants/all/templates/components/daily-block-native-ad.marko
+++ b/tenants/all/templates/components/daily-block-native-ad.marko
@@ -88,7 +88,7 @@ $ const imgStyles = {
     <!-- End of Image -->
 
     <!-- Headline -->
-    <marko-core-obj-text obj=node field="name" attrs={ style: headlineStyle }>
+    <marko-core-obj-text obj=node field="name" html=true attrs={ style: headlineStyle }>
       <@link href=node.siteContext.url target="_blank" attrs={ style: linkStyle }>
         <@after>
           <common-dpm-content

--- a/tenants/all/templates/components/daily-element-content-hero.marko
+++ b/tenants/all/templates/components/daily-element-content-hero.marko
@@ -90,7 +90,7 @@ $ const byline = node.byline || authors.join(', ');
 <if(node)>
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="web" style="overflow: hidden; margin: 5px 0; padding: 5px 0; clear: both; background-color: #fff;">
-    <marko-core-obj-text obj=node tag="h2" field="name" attrs={ style: headlineStyle } >
+    <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } >
       <@link href=node.siteContext.url target="_blank" attrs={ style: headlineLinkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />

--- a/tenants/all/templates/components/daily-element-content-sponsored.marko
+++ b/tenants/all/templates/components/daily-element-content-sponsored.marko
@@ -66,7 +66,7 @@ $ const readMoreLinkStyles = {
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px;padding:0px;border-collapse:collapse; border: 3px solid #FF9900; background-color:#FFFFFF; clear:both;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="borderfixWhite branded " style="overflow: hidden;margin-bottom: 9px;padding: 8px 12px 4px;background-color: #fff;border: 3px solid #FF9900;">
     <h4 style="font-size:11px; line-height:19px; margin:0px; padding:0px; text-align:left; font-weight:bold; letter-spacing:1px; text-transform:uppercase; color:#666666; font-family:Helvetica,Arial,sans-serif; color:#FF9900; border-bottom:2px solid #FF9900;">Sponsored</h4>
-    <marko-core-obj-text obj=node tag="h2" field="name" attrs={ style: h2Styles } >
+    <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: h2Styles } >
       <@link href=node.siteContext.url target="_blank" attrs={ style: linkStyles }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />

--- a/tenants/all/templates/components/daily-element-content-standard.marko
+++ b/tenants/all/templates/components/daily-element-content-standard.marko
@@ -77,7 +77,7 @@ $ const byline = node.byline || authors.join(', ');
 
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="web" style="overflow: hidden; margin: 5px 0; padding: 5px 0; clear: both; background-color: #fff;">
-    <marko-core-obj-text obj=node tag="h2" field="name" attrs={ style: headlineStyle } >
+    <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } >
       <@link href=node.siteContext.url target="_blank" attrs={ style: headlineLinkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />

--- a/tenants/all/templates/components/in-this-issue-block.marko
+++ b/tenants/all/templates/components/in-this-issue-block.marko
@@ -44,7 +44,7 @@ $ const nodeStyle = {
     <div class="category" style="padding: 0px 0px 1px;">
       <h1 style=headlineStyle>${sectionName}</h1>
       <for|node| of=nodes>
-        <marko-core-obj-text obj=node field="teaser" tag="h5" attrs={ style: nodeStyle } />
+        <marko-core-obj-text obj=node field="teaser" tag="h5" html=true attrs={ style: nodeStyle } />
       </for>
       <common-spacer-element />
     </div>


### PR DESCRIPTION
Mostly on items using content "name" field but additionally one for teaser.

<img width="1920" alt="Screen Shot 2021-11-22 at 9 49 29 AM" src="https://user-images.githubusercontent.com/46794001/142892547-2b83e7c6-d5cb-479f-bcf4-f6124af99db5.png">


