### PR TITLE
Add hero image to ‘fragrance’ and 'new products' block

### DIFF
--- a/tenants/all/templates/blp-newsletter.marko
+++ b/tenants/all/templates/blp-newsletter.marko
@@ -84,7 +84,6 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
       />
 

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -84,7 +84,6 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
       />
 

--- a/tenants/all/templates/me-newsletter.marko
+++ b/tenants/all/templates/me-newsletter.marko
@@ -84,7 +84,6 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
       />
 

--- a/tenants/all/templates/np-newsletter.marko
+++ b/tenants/all/templates/np-newsletter.marko
@@ -84,7 +84,6 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
       />
 

--- a/tenants/all/templates/pf-newsletter.marko
+++ b/tenants/all/templates/pf-newsletter.marko
@@ -82,7 +82,6 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="Fragrance"
-        with-hero=false
         dpm={ startingPosition: 300 }
       />
 

--- a/tenants/all/templates/si-newsletter.marko
+++ b/tenants/all/templates/si-newsletter.marko
@@ -82,7 +82,6 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
       />
 


### PR DESCRIPTION
<img width="885" alt="Screen Shot 2021-11-30 at 2 10 46 PM" src="https://user-images.githubusercontent.com/64623209/144122999-628799c8-02e2-4020-8cb1-35b5b3481f6d.png">
