### PR TITLE
Remove hero image on ‘New Products’ block

### DIFF
--- a/tenants/all/templates/blp-newsletter.marko
+++ b/tenants/all/templates/blp-newsletter.marko
@@ -91,6 +91,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
+        with-hero=false
         dpm={ startingPosition: 300 }
       />
 

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -91,6 +91,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
+        with-hero=false
         dpm={ startingPosition: 300 }
       />
 

--- a/tenants/all/templates/me-newsletter.marko
+++ b/tenants/all/templates/me-newsletter.marko
@@ -91,6 +91,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
+        with-hero=false
         dpm={ startingPosition: 300 }
       />
 

--- a/tenants/all/templates/np-newsletter.marko
+++ b/tenants/all/templates/np-newsletter.marko
@@ -91,6 +91,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
+        with-hero=false
         dpm={ startingPosition: 300 }
       />
 

--- a/tenants/all/templates/si-newsletter.marko
+++ b/tenants/all/templates/si-newsletter.marko
@@ -89,6 +89,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
+        with-hero=false
         dpm={ startingPosition: 300 }
       />
 

--- a/tenants/all/templates/si-special-edition.marko
+++ b/tenants/all/templates/si-special-edition.marko
@@ -89,6 +89,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         date=date
         newsletter=newsletter
         section-name="New Products"
+        with-hero=false
         dpm={ startingPosition: 300 }
       />
 


### PR DESCRIPTION
SI Special Edition, SI , NP, ME, DS, & BLP newsletters
<img width="704" alt="Screen Shot 2021-12-01 at 2 30 05 PM" src="https://user-images.githubusercontent.com/64623209/144309556-f351a174-09e9-413a-ab58-74a0cb91719d.png">
