### PR TITLE
Comment out ‘promotion slot’ 

### DIFF
--- a/tenants/all/templates/ct-digital-edition.marko
+++ b/tenants/all/templates/ct-digital-edition.marko
@@ -55,13 +55,13 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
     </div>
 
     <!-- Promotion Slot 1 -->
-    <daily-block-advertisement
+    <!-- <daily-block-advertisement
       date=date
       newsletter=newsletter
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
-    />
+    /> -->
 
     <!-- footer -->
     <daily-footer />

--- a/tenants/all/templates/gci-digital-edition.marko
+++ b/tenants/all/templates/gci-digital-edition.marko
@@ -55,13 +55,13 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
     </div>
 
     <!-- Promotion Slot 1 -->
-    <daily-block-advertisement
+    <!-- <daily-block-advertisement
       date=date
       newsletter=newsletter
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
-    />
+    /> -->
 
     <!-- footer -->
     <daily-footer />

--- a/tenants/all/templates/pf-digital-edition.marko
+++ b/tenants/all/templates/pf-digital-edition.marko
@@ -52,14 +52,14 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="In This Issue"
       />
 
-    <!-- Promotion Slot 1 -->
+    <!-- Promotion Slot 1
     <daily-block-advertisement
       date=date
       newsletter=newsletter
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
-    />
+    /> -->
 
     </div>
 

--- a/tenants/all/templates/si-digital-edition.marko
+++ b/tenants/all/templates/si-digital-edition.marko
@@ -55,13 +55,13 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
     </div>
 
     <!-- Promotion Slot 1 -->
-    <daily-block-advertisement
+    <!-- <daily-block-advertisement
       date=date
       newsletter=newsletter
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
-    />
+    /> -->
 
     <!-- footer -->
     <daily-footer />


### PR DESCRIPTION
This is the same for SI, PF, GCI, CT newsletters:
<img width="689" alt="Screen Shot 2021-12-13 at 7 45 11 AM" src="https://user-images.githubusercontent.com/64623209/145823825-4d5597da-7faf-4c99-ac30-866d5bda6a5d.png">
