### PR TITLE
AF-Feb2022 newsletter fixes

### DIFF
--- a/packages/common/components/dpm/emailx.marko
+++ b/packages/common/components/dpm/emailx.marko
@@ -38,7 +38,7 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
 
     $ const adStyle = (withHeader) ? withHeaderWrapperStyle : {}
     <if(withHeader)>
-      <!--[if (gte mso 9)|(lte IE 9)]><table width='600' bgcolor='#E5E5E5' align='center' cellpadding='0' cellspacing='0' border='0' style='margin:0px; padding:0px; border-collapse:collapse; background-color:#E5E5E5;' class='ieTableFix'><tr><td valign='top'><![endif]-->
+      <!--[if (gte mso 9)|(lte IE 9)]><table width="600" bgcolor="#E5E5E5" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#E5E5E5;" class="ieTableFix"><tr><td valign="top"><![endif]-->
     </if>
     <else>
       <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->

--- a/packages/common/components/dpm/emailx.marko
+++ b/packages/common/components/dpm/emailx.marko
@@ -37,6 +37,12 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
     $ const headerLabel = (withHeader) ? headerLabelHTML : "";
 
     $ const adStyle = (withHeader) ? withHeaderWrapperStyle : {}
+    <if(withHeader)>
+      <!--[if (gte mso 9)|(lte IE 9)]><table width='600' bgcolor='#E5E5E5' align='center' cellpadding='0' cellspacing='0' border='0' style='margin:0px; padding:0px; border-collapse:collapse; background-color:#E5E5E5;' class='ieTableFix'><tr><td valign='top'><![endif]-->
+    </if>
+    <else>
+      <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
+    </else>
     <div class="banner" style="margin:5px auto; padding:3px 0px 10px;min-width:300px !important; clear:both; overflow:hidden;">
       $!{headerLabel}
       <div ...input.attrs class=classNames style=adStyle>
@@ -73,6 +79,7 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
         </if>
       </div>
     </div>
+    <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><p class="ie" style="font-size: 1px; line-height: 15px; height: 15px; margin: 0px; padding: 0px; font-family: arial,sans-serif; text-align: left; color: #333; background-color: #FFFFFF; clear: both;">&nbsp;</p><![endif]-->
   </if>
   <else>
     <${input.whenEmpty} />

--- a/tenants/all/templates/components/daily-block-advertisement.marko
+++ b/tenants/all/templates/components/daily-block-advertisement.marko
@@ -93,4 +93,3 @@ $ const { sectionName, date, placementId } = input;
   />
 </else-if>
 
-<!--[if (gte mso 9)|(lte IE 9)]> </td></tr></table><![endif]-->

--- a/tenants/all/templates/components/daily-element-content-hero.marko
+++ b/tenants/all/templates/components/daily-element-content-hero.marko
@@ -98,7 +98,6 @@ $ const byline = node.byline || authors.join(', ');
       </@link>
     </marko-core-obj-text>
 
-    <!--[if gte mso 9]></td></tr></table><![endif]-->
     <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
       $ const imageOptions = {
         "width": "600px",

--- a/tenants/all/templates/components/daily-element-content-hero.marko
+++ b/tenants/all/templates/components/daily-element-content-hero.marko
@@ -102,7 +102,7 @@ $ const byline = node.byline || authors.join(', ');
       $ const imageOptions = {
         w: 600,
         h: 300,
-        ...!image.isLogo && { fit: "crop",crop:"faces" },
+        ...!image.isLogo && { fit: "crop", crop: "faces" },
       }
       <marko-newsletter-imgix
         src=image.src

--- a/tenants/all/templates/components/daily-element-content-hero.marko
+++ b/tenants/all/templates/components/daily-element-content-hero.marko
@@ -100,9 +100,9 @@ $ const byline = node.byline || authors.join(', ');
 
     <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
       $ const imageOptions = {
-        "width": "600px",
-        "height": "300px",
-        ...!image.isLogo && { fit: "crop" },
+        w: 600,
+        h: 300,
+        ...!image.isLogo && { fit: "crop",crop:"faces" },
       }
       <marko-newsletter-imgix
         src=image.src


### PR DESCRIPTION
[DPP-4937] & [DPP-4916] @solocommand @brandonbk 
Fixes for Outlook conditional comments and a fix for the cropping and resolution problem on the hero images. 

### Outlook Ad Background and spacing issue
Before: 
<img width="500" alt="outlook-before" src="https://user-images.githubusercontent.com/106970/153963556-bf087b56-1f7d-4639-acaf-8308d03d6c3c.jpg">

After:
<img width="500" alt="outlook-after" src="https://user-images.githubusercontent.com/106970/153963565-5fa4bc95-341e-46b2-8641-c4870d15c48b.jpg">


### Hero image cropping and resolution
Before (yes, it actually ran like this...):
<img width="500" alt="hero-image-before" src="https://user-images.githubusercontent.com/106970/153963580-b3013a5f-f318-4bc0-9848-0ebb7422b745.png">

After:
<img width="500" alt="hero-image-fix" src="https://user-images.githubusercontent.com/106970/153963594-49f4a2e9-141a-4a06-bc0f-a8624199d276.png">