### PR TITLE
AF Feb2022 UTM Params for Newsletters

### DIFF
--- a/packages/common/components/dpm/emailx.marko
+++ b/packages/common/components/dpm/emailx.marko
@@ -1,5 +1,6 @@
 import { getAsObject, get } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { URLSearchParams } from "url";
 
 $ const adUnit = getAsObject(input, "adUnit");
 $ const dpm = getAsObject(input, "dpm");
@@ -7,6 +8,8 @@ $ const dpm = getAsObject(input, "dpm");
 $ const useEmailxHref = defaultValue(input.useEmailxHref, false);
 
 $ const withHeader = defaultValue(input.withHeader, true);
+$ const urlParams = defaultValue(input.urlParams, false);
+$ const isPromoSlot = (adUnit.name == "promotion-slot-1" && !input.withHeader);
 
 $ const { name, alias } = adUnit;
 $ const classNames = [`email-x-${alias}-${name}`, input.class];
@@ -18,8 +21,12 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
     $ const { data, clickHref, imageSrc } = response;
     $ const { ad } = data;
 
+    $ const queryConnector = (ad.url && (ad.url.search(/\?/) + 1)) ? "&" : "?";
+    $ const queryString = (urlParams) ? `${queryConnector}${new URLSearchParams(urlParams)}` : "";
+    $ const adUrl = (isPromoSlot && urlParams) ? `${ad.url}${queryString}` : ad.url;
+
     <!-- determine whether to use emailx click url or the native ad url -->
-    $ const href = useEmailxHref ? clickHref : ad.url;
+    $ const href = useEmailxHref ? clickHref : adUrl;
     $ const imageAttrs = {
       ...getAsObject(input.image, "attrs"),
       width: ad.width,

--- a/packages/common/components/dpm/emailx.marko
+++ b/packages/common/components/dpm/emailx.marko
@@ -1,6 +1,6 @@
 import { getAsObject, get } from "@parameter1/base-cms-object-path";
+import buildUrl from "@allured-business-media/common/utils/build-link-url";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
-import { URLSearchParams } from "url";
 
 $ const adUnit = getAsObject(input, "adUnit");
 $ const dpm = getAsObject(input, "dpm");
@@ -21,12 +21,8 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
     $ const { data, clickHref, imageSrc } = response;
     $ const { ad } = data;
 
-    $ const queryConnector = (ad.url && (ad.url.search(/\?/) + 1)) ? "&" : "?";
-    $ const queryString = (urlParams) ? `${queryConnector}${new URLSearchParams(urlParams)}` : "";
-    $ const adUrl = (isPromoSlot && urlParams) ? `${ad.url}${queryString}` : ad.url;
-
     <!-- determine whether to use emailx click url or the native ad url -->
-    $ const href = useEmailxHref ? clickHref : adUrl;
+    $ const href = useEmailxHref ? clickHref : buildUrl({ url: ad.url, params: urlParams });
     $ const imageAttrs = {
       ...getAsObject(input.image, "attrs"),
       width: ad.width,

--- a/packages/common/components/dpm/marko.json
+++ b/packages/common/components/dpm/marko.json
@@ -36,6 +36,7 @@
     "@use-emailx-href": "boolean",
     "@class": "string",
     "@attrs": "object",
+    "@url-params": "object",
     "@with-header": "boolean"
   },
   "<common-dpm-digital-edition-cover-row>": {

--- a/packages/common/components/elements/advertisement.marko
+++ b/packages/common/components/elements/advertisement.marko
@@ -4,6 +4,7 @@ import { getAsObject } from "@parameter1/base-cms-object-path";
 $ const { config } = out.global;
 
 $ const adUnit = getAsObject(input, "adUnit");
+$ const urlParams = defaultValue(input.urlParams, false);
 
 <!-- merge the dpm input config with the global dpm config -->
 <!-- passing input directly to the component will override the global config values -->
@@ -22,6 +23,7 @@ $ const dpm = {
     use-emailx-href=defaultValue(dpm.useEmailxHref, false)
     when-empty=dpm.whenEmpty
     with-header=input.withHeader
+    url-params=urlParams
   >
     <!-- pass dpm ln, lc, lcv, lkw values if passed, otherwise the defaults will be used -->
     <@dpm ln=dpm.ln lc=dpm.lc lcv=dpm.lcv lkw=dpm.lkw position=dpm.position />

--- a/packages/common/components/elements/marko.json
+++ b/packages/common/components/elements/marko.json
@@ -15,6 +15,7 @@
     },
     "@ad-unit": "object",
     "@date": "date",
+    "@url-params": "object",
     "@with-header": "boolean"
   }
 }

--- a/packages/common/utils/build-link-url.js
+++ b/packages/common/utils/build-link-url.js
@@ -1,0 +1,17 @@
+const { URL, URLSearchParams } = require('url');
+
+module.exports = ({ url, params = {} }) => {
+  try {
+    const newUrl = new URL(url);
+    const parsed = new URL(url);
+    const search = Object.keys(params).reduce((sp, key) => {
+      const value = params[key];
+      sp.append(key, value);
+      return sp;
+    }, parsed.searchParams || new URLSearchParams());
+    newUrl.search = search;
+    return newUrl.toString();
+  } catch (e) {
+    return url;
+  }
+};

--- a/packages/common/utils/build-utm-params.js
+++ b/packages/common/utils/build-utm-params.js
@@ -1,0 +1,9 @@
+module.exports = ({ brand = '', date }) => {
+  const utmDate = date.format('MM-DD-YYYY');
+  const utmCampaign = `${brand} E-Newsletter ${utmDate}`;
+  return {
+    utm_source: 'newsletter-html',
+    utm_medium: 'email',
+    utm_campaign: utmCampaign,
+  };
+};

--- a/tenants/all/templates/blp-newsletter.marko
+++ b/tenants/all/templates/blp-newsletter.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/blp-newsletter.marko
+++ b/tenants/all/templates/blp-newsletter.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -73,6 +83,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -93,6 +104,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="New Products"
         with-hero=false
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -112,6 +124,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Trend Watch"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <!-- Upcoming Events -->
@@ -120,6 +133,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Upcoming Events"
         dpm={ startingPosition: 500 }
+        url-params=urlParams
       />
 
       <!-- Enter To Win -->
@@ -128,6 +142,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Enter To Win"
         dpm={ startingPosition: 600 }
+        url-params=urlParams
       />
 
       <!-- In Case You Missed It -->
@@ -136,6 +151,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 700 }
+        url-params=urlParams
       />
 
       <common-spacer-element />

--- a/tenants/all/templates/components/daily-block-advertisement.marko
+++ b/tenants/all/templates/components/daily-block-advertisement.marko
@@ -1,4 +1,5 @@
 import { getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
 import { convertAdToContent } from "@allured-business-media/common/native-x";
 
@@ -8,6 +9,7 @@ $ const nativeX = config.getAsObject("nativeX");
 $ const adUnit = getAsObject(input, "adUnit");
 $ const newsletter = getAsObject(input, "newsletter");
 $ const { sectionName, date, placementId } = input;
+$ const urlParams = defaultValue(input.urlParams, false);
 
 <if(nativeX.uri && placementId)>
   <native-x-fetch|{ data: nxData }| uri=nativeX.uri date=date placement-id=placementId>
@@ -90,6 +92,7 @@ $ const { sectionName, date, placementId } = input;
     date=date
     dpm=input.dpm
     with-header=input.withHeader
+    url-params=urlParams
   />
 </else-if>
 

--- a/tenants/all/templates/components/daily-block-featured.marko
+++ b/tenants/all/templates/components/daily-block-featured.marko
@@ -1,4 +1,5 @@
 import { getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
 import emailX from "../../config/email-x";
 
@@ -6,6 +7,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
 $ const { config } = out.global;
 $ const { date, newsletter, sectionName, limit } = input;
 $ const dpm = getAsObject(input, 'dpm');
+$ const urlParams = defaultValue(input.urlParams, false);
 
 <!--[if (gte mso 9)|(lte IE 9)]><table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse;" class="ieTableFix"><tr><td valign="top"><![endif]-->
 <div class="category" style="padding: 0px 0px 1px;">
@@ -20,12 +22,12 @@ $ const dpm = getAsObject(input, 'dpm');
     $ const heroNode = nodes.slice(0, 1)[0];
     $ const listNodes = nodes.slice(1);
     $ nodePosition += 1;
-    <daily-element-content-hero node=heroNode dpm={ position: nodePosition } />
+    <daily-element-content-hero node=heroNode dpm={ position: nodePosition } url-params=urlParams />
     <common-spacer-element />
 
     <for|node| of=listNodes>
       $ nodePosition += 1;
-      <daily-element-content-standard node=node dpm={ position: nodePosition } />
+      <daily-element-content-standard node=node dpm={ position: nodePosition } url-params=urlParams />
       <common-spacer-element />
     </for>
   </marko-web-query>

--- a/tenants/all/templates/components/daily-block-standard.marko
+++ b/tenants/all/templates/components/daily-block-standard.marko
@@ -11,6 +11,7 @@ $ const limit = defaultValue(input.limit, 10);
 $ const title = defaultValue(input.title, sectionName);
 $ const withHero = defaultValue(input.withHero, true);
 $ const dpm = getAsObject(input, 'dpm');
+$ const urlParams = defaultValue(input.urlParams, false);
 
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
   date: date.valueOf(),
@@ -28,16 +29,16 @@ $ const dpm = getAsObject(input, 'dpm');
       $ const heroNode = nodes.slice(0, 1)[0];
       $ const listNodes = nodes.slice(1);
       $ nodePosition += 1;
-      <daily-element-content-hero node=heroNode dpm={ position: nodePosition } />
+      <daily-element-content-hero node=heroNode dpm={ position: nodePosition } url-params=urlParams />
       <for|node| of=listNodes>
         $ nodePosition += 1;
-        <daily-element-content-standard node=node dpm={ position: nodePosition } />
+        <daily-element-content-standard node=node dpm={ position: nodePosition } url-params=urlParams />
       </for>
     </if>
     <else>
       <for|node| of=nodes>
         $ nodePosition += 1;
-        <daily-element-content-standard node=node dpm={ position: nodePosition } />
+        <daily-element-content-standard node=node dpm={ position: nodePosition } url-params=urlParams />
       </for>
     </else>
   </div>

--- a/tenants/all/templates/components/daily-element-content-hero.marko
+++ b/tenants/all/templates/components/daily-element-content-hero.marko
@@ -1,5 +1,7 @@
 import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
+import { URLSearchParams } from "url";
 
+$ const { urlParams } = input;
 $ const node = getAsObject(input, "node");
 $ const labels = getAsArray(input, "node.labels");
 
@@ -88,10 +90,15 @@ $ const authors = getAsArray(node, "authors.edges").map(edge => get(edge, "node.
 $ const byline = node.byline || authors.join(', ');
 
 <if(node)>
+  $ const contentUrlContext = node.siteContext.url;
+  $ const queryConnector = (contentUrlContext && (contentUrlContext.search(/\?/) + 1)) ? "&" : "?";
+  $ const queryString = (urlParams) ? `${queryConnector}${new URLSearchParams(urlParams)}` : "";
+  $ const contentUrl = `${contentUrlContext}${queryString}`;
+
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="web" style="overflow: hidden; margin: 5px 0; padding: 5px 0; clear: both; background-color: #fff;">
     <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } >
-      <@link href=node.siteContext.url target="_blank" attrs={ style: headlineLinkStyle }>
+      <@link href=contentUrl target="_blank" attrs={ style: headlineLinkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>
@@ -111,7 +118,7 @@ $ const byline = node.byline || authors.join(', ');
         class="main"
         attrs={ border: 0, width: 600, align: "center", vspace: 5, style: imgStyles }
       >
-        <@link href=node.siteContext.url target="_blank" attrs={ style: imgLinkStyles }>
+        <@link href=contentUrl target="_blank" attrs={ style: imgLinkStyles }>
           <@after>
             <common-dpm-content node=node dpm=input.dpm />
           </@after>
@@ -126,7 +133,7 @@ $ const byline = node.byline || authors.join(', ');
     <marko-core-obj-text tag="p" class="abstract" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
 
     <marko-core-text tag="p" value="Read More →" attrs={ style: readMoreStyle }>
-      <@link href=node.siteContext.url target="_blank" attrs={ style: linkStyle }>
+      <@link href=contentUrl target="_blank" attrs={ style: linkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>

--- a/tenants/all/templates/components/daily-element-content-hero.marko
+++ b/tenants/all/templates/components/daily-element-content-hero.marko
@@ -1,7 +1,8 @@
 import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
-import { URLSearchParams } from "url";
+import buildUrl from "@allured-business-media/common/utils/build-link-url";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { urlParams } = input;
+$ const urlParams = defaultValue(input.urlParams, {});
 $ const node = getAsObject(input, "node");
 $ const labels = getAsArray(input, "node.labels");
 
@@ -90,15 +91,11 @@ $ const authors = getAsArray(node, "authors.edges").map(edge => get(edge, "node.
 $ const byline = node.byline || authors.join(', ');
 
 <if(node)>
-  $ const contentUrlContext = node.siteContext.url;
-  $ const queryConnector = (contentUrlContext && (contentUrlContext.search(/\?/) + 1)) ? "&" : "?";
-  $ const queryString = (urlParams) ? `${queryConnector}${new URLSearchParams(urlParams)}` : "";
-  $ const contentUrl = `${contentUrlContext}${queryString}`;
 
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="web" style="overflow: hidden; margin: 5px 0; padding: 5px 0; clear: both; background-color: #fff;">
     <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } >
-      <@link href=contentUrl target="_blank" attrs={ style: headlineLinkStyle }>
+      <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: headlineLinkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>
@@ -118,7 +115,7 @@ $ const byline = node.byline || authors.join(', ');
         class="main"
         attrs={ border: 0, width: 600, align: "center", vspace: 5, style: imgStyles }
       >
-        <@link href=contentUrl target="_blank" attrs={ style: imgLinkStyles }>
+        <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: imgLinkStyles }>
           <@after>
             <common-dpm-content node=node dpm=input.dpm />
           </@after>
@@ -133,7 +130,7 @@ $ const byline = node.byline || authors.join(', ');
     <marko-core-obj-text tag="p" class="abstract" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
 
     <marko-core-text tag="p" value="Read More →" attrs={ style: readMoreStyle }>
-      <@link href=contentUrl target="_blank" attrs={ style: linkStyle }>
+      <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: linkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>

--- a/tenants/all/templates/components/daily-element-content-sponsored.marko
+++ b/tenants/all/templates/components/daily-element-content-sponsored.marko
@@ -1,8 +1,10 @@
 import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path"
-import { URLSearchParams } from "url";
+import buildUrl from "@allured-business-media/common/utils/build-link-url";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const urlParams = defaultValue(input.urlParams, {});
 
 $ const node = getAsObject(input, "node");
-$ const { urlParams } = input;
 
 $ const h2Styles = {
   "font-size": "20px",
@@ -65,16 +67,12 @@ $ const readMoreLinkStyles = {
 };
 
 <if(node)>
-  $ const contentUrlContext = node.siteContext.url;
-  $ const queryConnector = (contentUrlContext && (contentUrlContext.search(/\?/) + 1)) ? "&" : "?";
-  $ const queryString = (urlParams) ? `${queryConnector}${new URLSearchParams(urlParams)}` : "";
-  $ const contentUrl = `${contentUrlContext}${queryString}`;
 
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px;padding:0px;border-collapse:collapse; border: 3px solid #FF9900; background-color:#FFFFFF; clear:both;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="borderfixWhite branded " style="overflow: hidden;margin-bottom: 9px;padding: 8px 12px 4px;background-color: #fff;border: 3px solid #FF9900;">
     <h4 style="font-size:11px; line-height:19px; margin:0px; padding:0px; text-align:left; font-weight:bold; letter-spacing:1px; text-transform:uppercase; color:#666666; font-family:Helvetica,Arial,sans-serif; color:#FF9900; border-bottom:2px solid #FF9900;">Sponsored</h4>
     <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: h2Styles } >
-      <@link href=contentUrl target="_blank" attrs={ style: linkStyles }>
+      <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: linkStyles }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>
@@ -89,7 +87,7 @@ $ const readMoreLinkStyles = {
         class="main"
         attrs={ border: 0, width: 115, h: 115, align: "left", hspace: 10, style: imgStyles }
       >
-        <@link href=contentUrl target="_blank" attrs={ style: imgLinkStyles }>
+        <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: imgLinkStyles }>
           <@after>
             <common-dpm-content node=node dpm=input.dpm />
           </@after>
@@ -100,7 +98,7 @@ $ const readMoreLinkStyles = {
 
     <marko-core-obj-text tag="p" class="abstract" obj=node field="teaser" html=true attrs={ style: teaserStyles } />
     <marko-core-text tag="p" value="Read More →" attrs={ style: readMoreStyles }>
-      <@link href=contentUrl target="_blank" attrs={ style: readMoreLinkStyles }>
+      <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: readMoreLinkStyles }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>

--- a/tenants/all/templates/components/daily-element-content-sponsored.marko
+++ b/tenants/all/templates/components/daily-element-content-sponsored.marko
@@ -1,6 +1,8 @@
 import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path"
+import { URLSearchParams } from "url";
 
 $ const node = getAsObject(input, "node");
+$ const { urlParams } = input;
 
 $ const h2Styles = {
   "font-size": "20px",
@@ -63,11 +65,16 @@ $ const readMoreLinkStyles = {
 };
 
 <if(node)>
+  $ const contentUrlContext = node.siteContext.url;
+  $ const queryConnector = (contentUrlContext && (contentUrlContext.search(/\?/) + 1)) ? "&" : "?";
+  $ const queryString = (urlParams) ? `${queryConnector}${new URLSearchParams(urlParams)}` : "";
+  $ const contentUrl = `${contentUrlContext}${queryString}`;
+
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px;padding:0px;border-collapse:collapse; border: 3px solid #FF9900; background-color:#FFFFFF; clear:both;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="borderfixWhite branded " style="overflow: hidden;margin-bottom: 9px;padding: 8px 12px 4px;background-color: #fff;border: 3px solid #FF9900;">
     <h4 style="font-size:11px; line-height:19px; margin:0px; padding:0px; text-align:left; font-weight:bold; letter-spacing:1px; text-transform:uppercase; color:#666666; font-family:Helvetica,Arial,sans-serif; color:#FF9900; border-bottom:2px solid #FF9900;">Sponsored</h4>
     <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: h2Styles } >
-      <@link href=node.siteContext.url target="_blank" attrs={ style: linkStyles }>
+      <@link href=contentUrl target="_blank" attrs={ style: linkStyles }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>
@@ -82,7 +89,7 @@ $ const readMoreLinkStyles = {
         class="main"
         attrs={ border: 0, width: 115, h: 115, align: "left", hspace: 10, style: imgStyles }
       >
-        <@link href=node.siteContext.url target="_blank" attrs={ style: imgLinkStyles }>
+        <@link href=contentUrl target="_blank" attrs={ style: imgLinkStyles }>
           <@after>
             <common-dpm-content node=node dpm=input.dpm />
           </@after>
@@ -93,7 +100,7 @@ $ const readMoreLinkStyles = {
 
     <marko-core-obj-text tag="p" class="abstract" obj=node field="teaser" html=true attrs={ style: teaserStyles } />
     <marko-core-text tag="p" value="Read More →" attrs={ style: readMoreStyles }>
-      <@link href=node.siteContext.url target="_blank" attrs={ style: readMoreLinkStyles }>
+      <@link href=contentUrl target="_blank" attrs={ style: readMoreLinkStyles }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>

--- a/tenants/all/templates/components/daily-element-content-standard.marko
+++ b/tenants/all/templates/components/daily-element-content-standard.marko
@@ -1,7 +1,9 @@
 import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
-import { URLSearchParams } from "url";
+import buildUrl from "@allured-business-media/common/utils/build-link-url";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { urlParams } = input;
+$ const urlParams = defaultValue(input.urlParams, {});
+
 $ const node = getAsObject(input, "node");
 $ const labels = getAsArray(input, "node.labels");
 
@@ -76,15 +78,11 @@ $ const byline = node.byline || authors.join(', ');
   <daily-element-content-sponsored node=node dpm=input.dpm url-params=urlParams />
 </if>
 <else-if(node)>
-  $ const contentUrlContext = node.siteContext.url;
-  $ const queryConnector = (contentUrlContext && (contentUrlContext.search(/\?/) + 1)) ? "&" : "?";
-  $ const queryString = (urlParams) ? `${queryConnector}${new URLSearchParams(urlParams)}` : "";
-  $ const contentUrl = `${contentUrlContext}${queryString}`;
 
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="web" style="overflow: hidden; margin: 5px 0; padding: 5px 0; clear: both; background-color: #fff;">
     <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } >
-      <@link href=contentUrl target="_blank" attrs={ style: headlineLinkStyle }>
+      <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: headlineLinkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>
@@ -98,7 +96,7 @@ $ const byline = node.byline || authors.join(', ');
     <marko-core-obj-text tag="p" class="abstract" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
 
     <marko-core-text tag="p" value="Read More →" attrs={ style: readMoreStyle }>
-      <@link href=contentUrl target="_blank" attrs={ style: linkStyle }>
+      <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: linkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>

--- a/tenants/all/templates/components/daily-element-content-standard.marko
+++ b/tenants/all/templates/components/daily-element-content-standard.marko
@@ -1,5 +1,7 @@
 import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
+import { URLSearchParams } from "url";
 
+$ const { urlParams } = input;
 $ const node = getAsObject(input, "node");
 $ const labels = getAsArray(input, "node.labels");
 
@@ -71,14 +73,18 @@ $ const authors = getAsArray(node, "authors.edges").map(edge => get(edge, "node.
 $ const byline = node.byline || authors.join(', ');
 
 <if(labels && labels.includes("Sponsored"))>
-  <daily-element-content-sponsored node=node dpm=input.dpm />
+  <daily-element-content-sponsored node=node dpm=input.dpm url-params=urlParams />
 </if>
 <else-if(node)>
+  $ const contentUrlContext = node.siteContext.url;
+  $ const queryConnector = (contentUrlContext && (contentUrlContext.search(/\?/) + 1)) ? "&" : "?";
+  $ const queryString = (urlParams) ? `${queryConnector}${new URLSearchParams(urlParams)}` : "";
+  $ const contentUrl = `${contentUrlContext}${queryString}`;
 
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="web" style="overflow: hidden; margin: 5px 0; padding: 5px 0; clear: both; background-color: #fff;">
     <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } >
-      <@link href=node.siteContext.url target="_blank" attrs={ style: headlineLinkStyle }>
+      <@link href=contentUrl target="_blank" attrs={ style: headlineLinkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>
@@ -92,7 +98,7 @@ $ const byline = node.byline || authors.join(', ');
     <marko-core-obj-text tag="p" class="abstract" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
 
     <marko-core-text tag="p" value="Read More →" attrs={ style: readMoreStyle }>
-      <@link href=node.siteContext.url target="_blank" attrs={ style: linkStyle }>
+      <@link href=contentUrl target="_blank" attrs={ style: linkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>

--- a/tenants/all/templates/ct-breaking-news.marko
+++ b/tenants/all/templates/ct-breaking-news.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/ct-breaking-news.marko
+++ b/tenants/all/templates/ct-breaking-news.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       section-name="Headline"
       limit=10
       dpm={ startingPosition: 100 }
+      url-params=urlParams
     />
 
     <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     />
 
     <daily-block-advertisement

--- a/tenants/all/templates/ct-newsletter-am.marko
+++ b/tenants/all/templates/ct-newsletter-am.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/ct-newsletter-am.marko
+++ b/tenants/all/templates/ct-newsletter-am.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -72,6 +82,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Formulating"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -90,6 +101,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -108,6 +120,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Archived"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <common-spacer-element />

--- a/tenants/all/templates/ct-newsletter-pm.marko
+++ b/tenants/all/templates/ct-newsletter-pm.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/ct-newsletter-pm.marko
+++ b/tenants/all/templates/ct-newsletter-pm.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -72,6 +82,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -90,6 +101,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Formulating"
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -108,6 +120,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <common-spacer-element />

--- a/tenants/all/templates/ct-special-edition.marko
+++ b/tenants/all/templates/ct-special-edition.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/ct-special-edition.marko
+++ b/tenants/all/templates/ct-special-edition.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -72,6 +82,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -90,6 +101,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Formulating"
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -106,6 +118,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <daily-block-advertisement

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `WS E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = "WS";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `WS E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -73,6 +83,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -93,6 +104,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="New Products"
         with-hero=false
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -112,6 +124,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Try It Tuesday"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <!-- Wellness -->
@@ -120,6 +133,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Wellness"
         dpm={ startingPosition: 500 }
+        url-params=urlParams
       />
 
       <!-- Spas -->
@@ -128,6 +142,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Spas"
         dpm={ startingPosition: 600 }
+        url-params=urlParams
       />
 
       <!-- Business -->
@@ -136,6 +151,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Business"
         dpm={ startingPosition: 700 }
+        url-params=urlParams
       />
 
       <!-- Skin and Body -->
@@ -144,6 +160,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Skin and Body"
         dpm={ startingPosition: 800 }
+        url-params=urlParams
       />
 
       <!-- In Case You Missed It -->
@@ -152,6 +169,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 900 }
+        url-params=urlParams
       />
 
       <common-spacer-element />

--- a/tenants/all/templates/gci-breaking-news.marko
+++ b/tenants/all/templates/gci-breaking-news.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/gci-breaking-news.marko
+++ b/tenants/all/templates/gci-breaking-news.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       section-name="Headline"
       limit=10
       dpm={ startingPosition: 100 }
+      url-params=urlParams
     />
 
     <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     />
 
     <daily-block-advertisement

--- a/tenants/all/templates/gci-newsletter-am.marko
+++ b/tenants/all/templates/gci-newsletter-am.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -72,6 +82,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -90,6 +101,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="News & Insights"
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -108,6 +120,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <common-spacer-element />

--- a/tenants/all/templates/gci-newsletter-am.marko
+++ b/tenants/all/templates/gci-newsletter-am.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/gci-newsletter-pm.marko
+++ b/tenants/all/templates/gci-newsletter-pm.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -72,6 +82,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -90,6 +101,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="News & Insights"
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -108,6 +120,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <common-spacer-element />

--- a/tenants/all/templates/gci-newsletter-pm.marko
+++ b/tenants/all/templates/gci-newsletter-pm.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/gci-special-edition.marko
+++ b/tenants/all/templates/gci-special-edition.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/gci-special-edition.marko
+++ b/tenants/all/templates/gci-special-edition.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -72,6 +82,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -90,6 +101,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="News & Insights"
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -106,6 +118,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <daily-block-advertisement

--- a/tenants/all/templates/me-newsletter.marko
+++ b/tenants/all/templates/me-newsletter.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/me-newsletter.marko
+++ b/tenants/all/templates/me-newsletter.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -73,6 +83,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -93,6 +104,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="New Products"
         with-hero=false
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -112,6 +124,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Research"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <!-- FDA Approvals -->
@@ -120,6 +133,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="FDA Approvals"
         dpm={ startingPosition: 500 }
+        url-params=urlParams
       />
 
       <!-- Practice Management -->
@@ -128,6 +142,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Practice Management"
         dpm={ startingPosition: 600 }
+        url-params=urlParams
       />
 
       <!-- In Case You Missed It -->
@@ -136,6 +151,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 700 }
+        url-params=urlParams
       />
 
       <common-spacer-element />

--- a/tenants/all/templates/np-newsletter.marko
+++ b/tenants/all/templates/np-newsletter.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -73,6 +83,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -93,6 +104,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="New Products"
         with-hero=false
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -112,6 +124,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Business"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <!-- Now Trending -->
@@ -120,6 +133,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Now Trending"
         dpm={ startingPosition: 500 }
+        url-params=urlParams
       />
 
       <!-- Mani Mondays -->
@@ -129,6 +143,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Mani Mondays"
         ad-position="secondary"
         dpm={ startingPosition: 600 }
+        url-params=urlParams
       />
 
       <!-- Technique -->
@@ -137,6 +152,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Technique"
         dpm={ startingPosition: 700 }
+        url-params=urlParams
       />
 
       <!-- Health -->
@@ -145,6 +161,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Health"
         dpm={ startingPosition: 800 }
+        url-params=urlParams
       />
 
       <!-- Style -->
@@ -153,6 +170,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Style"
         dpm={ startingPosition: 900 }
+        url-params=urlParams
       />
 
       <!-- Nail Art -->
@@ -161,6 +179,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Nail Art"
         dpm={ startingPosition: 1000 }
+        url-params=urlParams
       />
 
       <!-- In Case You Missed It -->
@@ -169,6 +188,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 1100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />

--- a/tenants/all/templates/np-newsletter.marko
+++ b/tenants/all/templates/np-newsletter.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/pf-breaking-news.marko
+++ b/tenants/all/templates/pf-breaking-news.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/pf-breaking-news.marko
+++ b/tenants/all/templates/pf-breaking-news.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       section-name="Headline"
       limit=10
       dpm={ startingPosition: 100 }
+      url-params=urlParams
     />
 
     <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     />
 
     <daily-block-advertisement

--- a/tenants/all/templates/pf-newsletter.marko
+++ b/tenants/all/templates/pf-newsletter.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/pf-newsletter.marko
+++ b/tenants/all/templates/pf-newsletter.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -72,6 +82,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Flavor"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -90,6 +101,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Fragrance"
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -108,6 +120,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <common-spacer-element />

--- a/tenants/all/templates/pf-special-edition.marko
+++ b/tenants/all/templates/pf-special-edition.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/pf-special-edition.marko
+++ b/tenants/all/templates/pf-special-edition.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -72,6 +82,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Flavor"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -90,6 +101,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Fragrance"
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -106,6 +118,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <daily-block-advertisement

--- a/tenants/all/templates/si-breaking-news.marko
+++ b/tenants/all/templates/si-breaking-news.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/si-breaking-news.marko
+++ b/tenants/all/templates/si-breaking-news.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       section-name="Headline"
       limit=10
       dpm={ startingPosition: 100 }
+      url-params=urlParams
     />
 
     <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     />
 
     <daily-block-advertisement

--- a/tenants/all/templates/si-newsletter.marko
+++ b/tenants/all/templates/si-newsletter.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name

--- a/tenants/all/templates/si-newsletter.marko
+++ b/tenants/all/templates/si-newsletter.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -72,6 +82,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -91,6 +102,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="New Products"
         with-hero=false
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -109,6 +121,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -127,6 +140,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Partners"
         dpm={ startingPosition: 500 }
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/si-special-edition.marko
+++ b/tenants/all/templates/si-special-edition.marko
@@ -10,6 +10,14 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
+$ const utmSource = "newsletter-html";
+$ const utmMedium = "email";
+$ const utmBrand = get(newsletter, "site.shortName") || "";
+$ const utmDate = date.format("MM-DD-YYYY");
+$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
+$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
+$ const urlParams = (utmParams) ? utmParams : false;
+
 <marko-newsletter-root
   title=newsletter.name
   description=newsletter.description
@@ -45,6 +53,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="Headline"
         limit=10
         dpm={ startingPosition: 100 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -56,6 +65,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -72,6 +82,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Industry News"
         dpm={ startingPosition: 200 }
+        url-params=urlParams
       />
 
       <common-spacer-element />
@@ -91,6 +102,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         section-name="New Products"
         with-hero=false
         dpm={ startingPosition: 300 }
+        url-params=urlParams
       />
 
       <daily-block-advertisement
@@ -107,6 +119,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="In Case You Missed It"
         dpm={ startingPosition: 400 }
+        url-params=urlParams
       />
 
       <daily-block-advertisement

--- a/tenants/all/templates/si-special-edition.marko
+++ b/tenants/all/templates/si-special-edition.marko
@@ -1,5 +1,6 @@
 import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
@@ -10,13 +11,8 @@ $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
 
-$ const utmSource = "newsletter-html";
-$ const utmMedium = "email";
-$ const utmBrand = get(newsletter, "site.shortName") || "";
-$ const utmDate = date.format("MM-DD-YYYY");
-$ const utmCampaign = `${utmBrand} E-Newsletter ${utmDate}`;
-$ const utmParams = {"utm_source" : utmSource, "utm_medium" : utmMedium, "utm_campaign" : utmCampaign};
-$ const urlParams = (utmParams) ? utmParams : false;
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const urlParams = buildUtmParams({ brand, date });
 
 <marko-newsletter-root
   title=newsletter.name


### PR DESCRIPTION
I referred to another client's code as an example of how best to do this, but if there is a better way, please let me know. Otherwise these changes should support passing url params to the links on all content items in our main newsletters as well as our Digital Magazine promotion item that usually runs above the first real ad. Right now the main goal was to support adding back in our UTM tracking code on each link that we previously had on Clickability. But this could be used for other URL params in the future if needed. 
Please let me know if you see any issues with this approach. 
@brandonbk @solocommand 