### PR TITLE
AF Apr2022 Headers And UTM Additions

### DIFF
--- a/packages/common/components/blocks/publication-issue-cover.marko
+++ b/packages/common/components/blocks/publication-issue-cover.marko
@@ -1,5 +1,8 @@
 import latestIssueFragment from "@allured-business-media/common/graphql/fragments/latest-issue";
+import buildUrl from "@allured-business-media/common/utils/build-link-url";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const urlParams = defaultValue(input.urlParams, {});
 
 $ const { config } = out.global;
 $ const { date, newsletter, publicationId, imgWidth } = input;
@@ -19,14 +22,14 @@ $ const { date, newsletter, publicationId, imgWidth } = input;
       class="main"
       attrs={ border: 0, width: imgWidth }
     >
-      <@link href=latestIssue.digitalEditionUrl  target="_blank" />
+      <@link href=buildUrl({ url: latestIssue.digitalEditionUrl, params: urlParams })  target="_blank" />
     </marko-newsletter-imgix>
   </marko-core-obj-value>
 
   <common-spacer-element style={ "line-height": "7px", "height": "7px" } />
 
   <h5 style="margin: 0px 0px 0px;padding: 0px 0px 0px;text-align: center;font-family: arial;font-weight: normal;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
-    <a href=latestIssue.digitalEditionUrl target="_blank" style="min-height:26px;line-height:26px;font-size:18px; padding: 0px 15px;margin: 0 5px 0px;border-radius:5px;font-weight: bold;color: #FFFFFF;text-decoration: none;border:1px solid #FFFFFF;display:inline-block; background-color:#000000;background-image: url(https://abm-email-images.s3.amazonaws.com/hr/shared/drk-gry-btn-bg.jpg); background-repeat: repeat-x; background-position: center center; background:#000 linear-gradient(to bottom, #888 0%, #222222 100%);box-shadow:0 0px 5px rgba(0,0,0,.5);">
+    <a href=buildUrl({ url: latestIssue.digitalEditionUrl, params: urlParams }) target="_blank" style="min-height:26px;line-height:26px;font-size:18px; padding: 0px 15px;margin: 0 5px 0px;border-radius:5px;font-weight: bold;color: #FFFFFF;text-decoration: none;border:1px solid #FFFFFF;display:inline-block; background-color:#000000;background-image: url(https://abm-email-images.s3.amazonaws.com/hr/shared/drk-gry-btn-bg.jpg); background-repeat: repeat-x; background-position: center center; background:#000 linear-gradient(to bottom, #888 0%, #222222 100%);box-shadow:0 0px 5px rgba(0,0,0,.5);">
     <span style="margin: 0 5px; padding: 0 5px; display:inline-block">&nbsp;View Issue&nbsp;</span>
     </a>
   </h5>

--- a/packages/common/components/dpm/digital-edition-cover-row.marko
+++ b/packages/common/components/dpm/digital-edition-cover-row.marko
@@ -15,6 +15,8 @@ $ const useEmailxHref = defaultValue(input.useEmailxHref, false);
 $ const { name, alias } = adUnit;
 $ const classNames = [`email-x-${alias}-${name}`, input.class];
 
+$ const urlParams = defaultValue(input.urlParams, false);
+
 <div style="padding: 1px 0px 1px; display: block; margin: 0 0 0px 0; overflow: hidden; position: relative;" id="header2">
 
   <!--[if (gte mso 9)|(lte IE 9)]><table width="590" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px;padding:0px;border:0px none;border-collapse:collapse;" class="ieTableFix"><tr><td valign="top" height="290" width="265" align="center" style="text-align:center;"><p style="font-size:1px; line-height:15px; height: 15px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
@@ -25,6 +27,7 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
       newsletter=input.newsletter
       publication-id=input.publicationId
       imgWidth=150
+      url-params=urlParams
     />
 
   </div>

--- a/packages/common/utils/build-utm-params.js
+++ b/packages/common/utils/build-utm-params.js
@@ -1,8 +1,9 @@
-module.exports = ({ brand = '', date }) => {
+module.exports = ({ brand = '', date, isDigital = false }) => {
   const utmDate = date.format('MM-DD-YYYY');
-  const utmCampaign = `${brand} E-Newsletter ${utmDate}`;
+  const utmSource = isDigital ? 'de-notification' : 'newsletter-html';
+  const utmCampaign = isDigital ? `${brand} Digital Magazine ${utmDate}` : `${brand} E-Newsletter ${utmDate}`;
   return {
-    utm_source: 'newsletter-html',
+    utm_source: utmSource,
     utm_medium: 'email',
     utm_campaign: utmCampaign,
   };

--- a/tenants/all/templates/blp-digital-edition.marko
+++ b/tenants/all/templates/blp-digital-edition.marko
@@ -1,10 +1,16 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
 $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const isDigital = true;
+$ const urlParams = buildUtmParams({ brand, date, isDigital });
 
 <marko-newsletter-root
   title=newsletter.name
@@ -39,6 +45,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
           date=date
           publication-id="5f3191b79ad4092e008b4574"
           ad-unit=adUnit
+          url-params=urlParams
         />
 
       </div>
@@ -61,6 +68,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     />
 
     <!-- footer -->

--- a/tenants/all/templates/components/daily-header.marko
+++ b/tenants/all/templates/components/daily-header.marko
@@ -30,7 +30,7 @@ $ const logoStyles = {
     <div id="branding" style="width: 100%; vertical-align: top; margin:0px auto 0px; overflow:hidden; position:relative; background-color: #fff;">
       <common-spacer-element />
       <div id="headline" style="max-width:100% !important; display:inline-block; vertical-align: bottom; margin:0px auto; overflow:hidden; text-align: center; background-color: #fff;">
-        <marko-newsletter-imgix src=input.imageSrc options={ w: 600 } alt=input.name attrs={ border: 0, width: 600, style: logoStyles }>
+        <marko-newsletter-imgix src=input.imageSrc options={ w: 800 } alt=input.name attrs={ border: 0, width: 600, style: logoStyles }>
           <@link href=input.href title=input.name target="_blank" />
         </marko-newsletter-imgix>
       </div>

--- a/tenants/all/templates/ct-digital-edition.marko
+++ b/tenants/all/templates/ct-digital-edition.marko
@@ -1,10 +1,16 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
 $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const isDigital = true;
+$ const urlParams = buildUtmParams({ brand, date, isDigital });
 
 <marko-newsletter-root
   title=newsletter.name
@@ -39,6 +45,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
           date=date
           publication-id="60997ea1a0dca4bb318b45df"
           ad-unit=adUnit
+          url-params=urlParams
         />
 
       </div>
@@ -61,6 +68,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     /> -->
 
     <!-- footer -->

--- a/tenants/all/templates/ds-digital-edition.marko
+++ b/tenants/all/templates/ds-digital-edition.marko
@@ -32,7 +32,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
       name=newsletter.name
       href=website.get("origin")
       date=date
-      image-src="/files/base/allured/all/image/static/newsletter/ws-ds-digital-edition-header.png"
+      image-src="/files/base/allured/all/image/static/newsletter/ws-digital-edition-header.png"
     />
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">

--- a/tenants/all/templates/ds-digital-edition.marko
+++ b/tenants/all/templates/ds-digital-edition.marko
@@ -1,10 +1,16 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
 $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+$ const brand = "WS";
+$ const isDigital = true;
+$ const urlParams = buildUtmParams({ brand, date, isDigital });
 
 <marko-newsletter-root
   title=newsletter.name
@@ -39,6 +45,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
           date=date
           publication-id="5f31978cfa5bba2e008b457a"
           ad-unit=adUnit
+          url-params=urlParams
         />
 
       </div>
@@ -61,6 +68,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     />
 
     <!-- footer -->

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -32,7 +32,7 @@ $ const urlParams = buildUtmParams({ brand, date });
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ws-ds-newsletter-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/ws-newsletter-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/ds-product-roundup.marko
+++ b/tenants/all/templates/ds-product-roundup.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ws-ds-product-roundup-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/ws-product-roundup-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/gci-digital-edition.marko
+++ b/tenants/all/templates/gci-digital-edition.marko
@@ -1,10 +1,16 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
 $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const isDigital = true;
+$ const urlParams = buildUtmParams({ brand, date, isDigital });
 
 <marko-newsletter-root
   title=newsletter.name
@@ -39,6 +45,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
           date=date
           publication-id="60997e602420fa65388b4574"
           ad-unit=adUnit
+          url-params=urlParams
         />
 
       </div>
@@ -61,6 +68,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     /> -->
 
     <!-- footer -->

--- a/tenants/all/templates/me-digital-edition.marko
+++ b/tenants/all/templates/me-digital-edition.marko
@@ -1,10 +1,16 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
 $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const isDigital = true;
+$ const urlParams = buildUtmParams({ brand, date, isDigital });
 
 <marko-newsletter-root
   title=newsletter.name
@@ -39,6 +45,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
           date=date
           publication-id="5f3197e5ed707d2d008b4578"
           ad-unit=adUnit
+          url-params=urlParams
         />
 
       </div>
@@ -61,6 +68,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     />
 
     <!-- footer -->

--- a/tenants/all/templates/np-digital-edition.marko
+++ b/tenants/all/templates/np-digital-edition.marko
@@ -1,10 +1,16 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
 $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const isDigital = true;
+$ const urlParams = buildUtmParams({ brand, date, isDigital });
 
 <marko-newsletter-root
   title=newsletter.name
@@ -39,6 +45,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
           date=date
           publication-id="5f232c7bc63b4017018b456a"
           ad-unit=adUnit
+          url-params=urlParams
         />
 
       </div>
@@ -61,6 +68,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     />
 
     <!-- footer -->

--- a/tenants/all/templates/np-digital-edition.marko
+++ b/tenants/all/templates/np-digital-edition.marko
@@ -32,7 +32,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
       name=newsletter.name
       href=website.get("origin")
       date=date
-      image-src="/files/base/allured/all/image/static/newsletter/np-2021-digital-edition-header.png"
+      image-src="/files/base/allured/all/image/static/newsletter/np-2022-digital-edition-header.png"
     />
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">

--- a/tenants/all/templates/np-newsletter.marko
+++ b/tenants/all/templates/np-newsletter.marko
@@ -32,7 +32,7 @@ $ const urlParams = buildUtmParams({ brand, date });
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/np-2021-newsletter-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/np-2022-newsletter-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/np-product-roundup.marko
+++ b/tenants/all/templates/np-product-roundup.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/np-2021-product-roundup-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/np-2022-product-roundup-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/pf-digital-edition.marko
+++ b/tenants/all/templates/pf-digital-edition.marko
@@ -1,10 +1,16 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
 $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const isDigital = true;
+$ const urlParams = buildUtmParams({ brand, date, isDigital });
 
 <marko-newsletter-root
   title=newsletter.name
@@ -39,6 +45,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
           date=date
           publication-id="60997de8e84a1620338b45db"
           ad-unit=adUnit
+          url-params=urlParams
         />
 
       </div>
@@ -59,6 +66,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     /> -->
 
     </div>

--- a/tenants/all/templates/si-digital-edition.marko
+++ b/tenants/all/templates/si-digital-edition.marko
@@ -1,10 +1,16 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import buildUtmParams from "@allured-business-media/common/utils/build-utm-params";
 import emailX from "../config/email-x";
 
 $ const { website, config } = out.global;
 $ const { newsletter, date } = data;
 
 $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+$ const brand = get(newsletter, "site.shortName") || "";
+$ const isDigital = true;
+$ const urlParams = buildUtmParams({ brand, date, isDigital });
 
 <marko-newsletter-root
   title=newsletter.name
@@ -39,6 +45,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
           date=date
           publication-id="60997d5c3e2ef0f9318b45d5"
           ad-unit=adUnit
+          url-params=urlParams
         />
 
       </div>
@@ -61,6 +68,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
+      url-params=urlParams
     /> -->
 
     <!-- footer -->


### PR DESCRIPTION
I expanded on the last set of UTM parameter tools to allow for slightly different values for the Digital Magazine emails. I applied that tracking to the main links in those email templates. 
This also updates some header images for a Nailpro and WellSpa newsletters. I'm also making a change to all newsletter header images to pull in a slightly higher res version by default, instead of the 600px standard. Many mail clients don't support the srcset attribute that allows for the higher res versions, so those fall back to the 600px version. I'm increasing that default to 800px just so mail clients that don't support the alternate version won't look so blurry on higher quality desktop displays. 

Covers Jira tickets: [DPP-5124] and [DPP-5149]

Here are the updated NP and WS headers:
<img width="500" alt="newsletter-logo-updates-2022" src="https://user-images.githubusercontent.com/106970/165561826-3a0aba96-d4e2-48d0-9fd4-b3cbc1101476.png">

@solocommand @brandonbk 
