### PR TITLE
AF May22 digi redesign DPP-5156

### DIFF
--- a/packages/common/components/dpm/content.marko
+++ b/packages/common/components/dpm/content.marko
@@ -4,6 +4,7 @@ $ const { isArray } = Array;
 $ const { config } = out.global;
 $ const { node, date } = input;
 $ const newsletter = getAsObject(input, "newsletter");
+$ const isDigital = get(input, "dpm.isDigital") || false;
 
 <!-- load the dpm content config -->
 $ const dpmConfig = config.getAsObject("dpm.content");
@@ -11,7 +12,7 @@ $ const dpmConfig = config.getAsObject("dpm.content");
 $ const enabledTypes = isArray(dpmConfig.types) ? dpmConfig.types : ["promotion", "text-ad"];
 <!-- dpm is enabled when `enabled` is set in the config and the current content type matches a configured type -->
 <!-- $ const dpmEnabled = dpmConfig.enabled && enabledTypes.includes(node.type); -->
-$ const dpmEnabled = dpmConfig.enabled;
+$ const dpmEnabled = isDigital ? false : dpmConfig.enabled;
 
 <!-- only render when enabled -->
 <if(dpmEnabled)>

--- a/tenants/all/templates/blp-digital-edition.marko
+++ b/tenants/all/templates/blp-digital-edition.marko
@@ -37,6 +37,13 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">
       <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
+      <digital-edition-overview-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      /> 
+      <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
       <div id="headers" style="background-color:#FFF;text-align: center; padding: 5px 0px; display: block; margin: 5px 0 5px; overflow: hidden; position: relative;">
 
         $ const adUnit = emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias });
@@ -50,18 +57,32 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
       </div>
 
-      <common-spacer-element />
+      <common-spacer-element 
+        style={
+          "font-size": "20px",
+          "line-height": "20px",
+          "height": "20px"
+        } 
+      />
 
       <!-- In This Issue -->
-      <in-this-issue-block
+      <!-- <in-this-issue-block
         date=date
         newsletter=newsletter
         section-name="In This Issue"
+      /> -->
+
+      <digital-edition-highlight-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        url-params=urlParams
+        limit=3
       />
 
     </div>
-
-    <!-- Promotion Slot 1 -->
+    
+    <!-- Promotion Slot 1
     <daily-block-advertisement
       date=date
       newsletter=newsletter
@@ -69,7 +90,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
       url-params=urlParams
-    />
+    /> -->
 
     <!-- footer -->
     <daily-footer />

--- a/tenants/all/templates/blp-digital-edition.marko
+++ b/tenants/all/templates/blp-digital-edition.marko
@@ -78,6 +78,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
         section-name="In This Issue"
         url-params=urlParams
         limit=3
+        dpm={ isDigital: isDigital }
       />
 
     </div>

--- a/tenants/all/templates/components/digital-edition-highlight-block.marko
+++ b/tenants/all/templates/components/digital-edition-highlight-block.marko
@@ -1,0 +1,40 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../../config/email-x";
+
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+$ const { config } = out.global;
+$ const { date, newsletter, sectionName, limit } = input;
+$ const dpm = getAsObject(input, 'dpm');
+$ const urlParams = defaultValue(input.urlParams, false);
+
+<!--[if (gte mso 9)|(lte IE 9)]><table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse;" class="ieTableFix"><tr><td valign="top"><![endif]-->
+<div class="category" style="padding: 0px 0px 1px;">
+  $ let nodePosition = dpm.startingPosition || 0;
+  <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+    date: date.valueOf(),
+    newsletterId: newsletter.id,
+    sectionName,
+    limit,
+    queryFragment,
+  }>
+    $ const heroNode = nodes.slice(0, 1)[0];
+    $ const listNodes = nodes.slice(1);
+    $ nodePosition += 1;
+    <daily-element-content-hero node=heroNode dpm={ position: nodePosition } url-params=urlParams />
+    <common-spacer-element />
+
+    <for|node| of=listNodes>
+      $ nodePosition += 1;
+      <daily-element-content-standard node=node dpm={ position: nodePosition } url-params=urlParams />
+      <common-spacer-element />
+    </for>
+  </marko-web-query>
+
+  <!-- <daily-block-magazine-spread newsletter=newsletter date=date /> -->
+
+  <common-spacer-element />
+
+</div>
+<!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->

--- a/tenants/all/templates/components/digital-edition-highlight-block.marko
+++ b/tenants/all/templates/components/digital-edition-highlight-block.marko
@@ -19,8 +19,8 @@ $ const urlParams = defaultValue(input.urlParams, false);
     limit,
     queryFragment,
   }>
-    $ const heroNode = nodes.slice(0, 1)[0];
-    $ const listNodes = nodes.slice(1);
+    $ const heroNode = nodes.slice(1, 2)[0];
+    $ const listNodes = nodes.slice(2);
     $ nodePosition += 1;
     <daily-element-content-hero node=heroNode dpm={ position: nodePosition } url-params=urlParams />
     <common-spacer-element />

--- a/tenants/all/templates/components/digital-edition-highlight-block.marko
+++ b/tenants/all/templates/components/digital-edition-highlight-block.marko
@@ -7,6 +7,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
 $ const { config } = out.global;
 $ const { date, newsletter, sectionName, limit } = input;
 $ const dpm = getAsObject(input, 'dpm');
+$ const isDigital = dpm.isDigital || true;
 $ const urlParams = defaultValue(input.urlParams, false);
 
 <!--[if (gte mso 9)|(lte IE 9)]><table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse;" class="ieTableFix"><tr><td valign="top"><![endif]-->
@@ -22,12 +23,12 @@ $ const urlParams = defaultValue(input.urlParams, false);
     $ const heroNode = nodes.slice(1, 2)[0];
     $ const listNodes = nodes.slice(2);
     $ nodePosition += 1;
-    <daily-element-content-hero node=heroNode dpm={ position: nodePosition } url-params=urlParams />
+    <daily-element-content-hero node=heroNode dpm={ position: nodePosition, isDigital: isDigital } url-params=urlParams />
     <common-spacer-element />
 
     <for|node| of=listNodes>
       $ nodePosition += 1;
-      <daily-element-content-standard node=node dpm={ position: nodePosition } url-params=urlParams />
+      <daily-element-content-standard node=node dpm={ position: nodePosition, isDigital: isDigital } url-params=urlParams />
       <common-spacer-element />
     </for>
   </marko-web-query>

--- a/tenants/all/templates/components/digital-edition-overview-block.marko
+++ b/tenants/all/templates/components/digital-edition-overview-block.marko
@@ -1,0 +1,51 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../../config/email-x";
+
+$ const { config } = out.global;
+$ const { date, newsletter, sectionName } = input;
+$ const limit = defaultValue(input.limit, 1);
+
+$ const headlineStyle = {
+  "font-size": "20px",
+  "line-height": "26px",
+  "margin": "0px 0px 3px 0px",
+  "padding": "0px 0px 3px 0px",
+  "color": "#000000",
+  "text-align": "left",
+  "font-family": "Helvetica,Arial,sans-serif",
+  "font-weight": "bold",
+};
+
+$ const teaserStyle = {
+  "padding": "2px 0px 2px 0px",
+  "margin": "2px 0px 2px 2px",
+  "font-size": "15px",
+  "line-height": "22px",
+  "font-family": "arial,sans-serif",
+  "text-align": "left",
+  "color": "#333;",
+};
+
+<marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+  date: date.valueOf(),
+  newsletterId: newsletter.id,
+  sectionName,
+  limit,
+  queryFragment,
+}>
+  <common-spacer-element />
+  <!--[if (gte mso 9)|(lte IE 9)]><table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse;" class="ieTableFix"><tr><td valign="top"><![endif]-->
+  <div class="category" style="padding: 0px 0px 1px !important;">
+    <for|node| of=nodes>
+        <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
+        <div class="web" style="overflow: hidden; margin: 1px 0; padding: 1px 0; clear: both; background-color: #fff;">
+            <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } />
+            <marko-core-obj-text tag="p" class="abstract" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+        </div>
+        <!--[if (gte mso 9)|(lte IE 9)]> </td></tr></table><p class="ie" style="font-size: 1px; line-height: 10px; height: 10px; margin: 0px; padding: 0px; font-family: arial,sans-serif; text-align: left; color: #333; background-color: #FFFFFF; clear: both;">&nbsp;</p><![endif]-->
+    </for>
+  </div>
+  <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+</marko-web-query>

--- a/tenants/all/templates/ct-digital-edition.marko
+++ b/tenants/all/templates/ct-digital-edition.marko
@@ -78,6 +78,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
         section-name="In This Issue"
         url-params=urlParams
         limit=3
+        dpm={ isDigital: isDigital }
       />
 
     </div>

--- a/tenants/all/templates/ct-digital-edition.marko
+++ b/tenants/all/templates/ct-digital-edition.marko
@@ -37,6 +37,13 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">
       <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
+      <digital-edition-overview-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      /> 
+      <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
       <div id="headers" style="background-color:#FFF;text-align: center; padding: 5px 0px; display: block; margin: 5px 0 5px; overflow: hidden; position: relative;">
 
         $ const adUnit = emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias });
@@ -50,19 +57,33 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
       </div>
 
-      <common-spacer-element />
+      <common-spacer-element 
+        style={
+          "font-size": "20px",
+          "line-height": "20px",
+          "height": "20px"
+        } 
+      />
 
       <!-- In This Issue -->
-      <in-this-issue-block
+      <!-- <in-this-issue-block
         date=date
         newsletter=newsletter
         section-name="In This Issue"
+      /> -->
+
+      <digital-edition-highlight-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        url-params=urlParams
+        limit=3
       />
 
     </div>
-
-    <!-- Promotion Slot 1 -->
-    <!-- <daily-block-advertisement
+    
+    <!-- Promotion Slot 1
+    <daily-block-advertisement
       date=date
       newsletter=newsletter
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })

--- a/tenants/all/templates/ds-digital-edition.marko
+++ b/tenants/all/templates/ds-digital-edition.marko
@@ -37,6 +37,13 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">
       <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
+      <digital-edition-overview-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      /> 
+      <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
       <div id="headers" style="background-color:#FFF;text-align: center; padding: 5px 0px; display: block; margin: 5px 0 5px; overflow: hidden; position: relative;">
 
         $ const adUnit = emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias });
@@ -50,18 +57,32 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
       </div>
 
-      <common-spacer-element />
+      <common-spacer-element 
+        style={
+          "font-size": "20px",
+          "line-height": "20px",
+          "height": "20px"
+        } 
+      />
 
-        <!-- In This Issue -->
-        <in-this-issue-block
-          date=date
-          newsletter=newsletter
-          section-name="In This Issue"
-        />
+      <!-- In This Issue -->
+      <!-- <in-this-issue-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+      /> -->
+
+      <digital-edition-highlight-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        url-params=urlParams
+        limit=3
+      />
 
     </div>
-
-    <!-- Promotion Slot 1 -->
+    
+    <!-- Promotion Slot 1
     <daily-block-advertisement
       date=date
       newsletter=newsletter
@@ -69,7 +90,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
       url-params=urlParams
-    />
+    /> -->
 
     <!-- footer -->
     <daily-footer />

--- a/tenants/all/templates/ds-digital-edition.marko
+++ b/tenants/all/templates/ds-digital-edition.marko
@@ -78,6 +78,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
         section-name="In This Issue"
         url-params=urlParams
         limit=3
+        dpm={ isDigital: isDigital }
       />
 
     </div>

--- a/tenants/all/templates/gci-digital-edition.marko
+++ b/tenants/all/templates/gci-digital-edition.marko
@@ -78,6 +78,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
         section-name="In This Issue"
         url-params=urlParams
         limit=3
+        dpm={ isDigital: isDigital }
       />
 
     </div>

--- a/tenants/all/templates/gci-digital-edition.marko
+++ b/tenants/all/templates/gci-digital-edition.marko
@@ -37,6 +37,13 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">
       <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
+      <digital-edition-overview-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      /> 
+      <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
       <div id="headers" style="background-color:#FFF;text-align: center; padding: 5px 0px; display: block; margin: 5px 0 5px; overflow: hidden; position: relative;">
 
         $ const adUnit = emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias });
@@ -50,19 +57,33 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
       </div>
 
-      <common-spacer-element />
+      <common-spacer-element 
+        style={
+          "font-size": "20px",
+          "line-height": "20px",
+          "height": "20px"
+        } 
+      />
 
       <!-- In This Issue -->
-      <in-this-issue-block
+      <!-- <in-this-issue-block
         date=date
         newsletter=newsletter
         section-name="In This Issue"
+      /> -->
+
+      <digital-edition-highlight-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        url-params=urlParams
+        limit=3
       />
 
     </div>
-
-    <!-- Promotion Slot 1 -->
-    <!-- <daily-block-advertisement
+    
+    <!-- Promotion Slot 1
+    <daily-block-advertisement
       date=date
       newsletter=newsletter
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })

--- a/tenants/all/templates/me-digital-edition.marko
+++ b/tenants/all/templates/me-digital-edition.marko
@@ -37,6 +37,13 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">
       <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
+      <digital-edition-overview-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      /> 
+      <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
       <div id="headers" style="background-color:#FFF;text-align: center; padding: 5px 0px; display: block; margin: 5px 0 5px; overflow: hidden; position: relative;">
 
         $ const adUnit = emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias });
@@ -50,18 +57,32 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
       </div>
 
-      <common-spacer-element />
+      <common-spacer-element 
+        style={
+          "font-size": "20px",
+          "line-height": "20px",
+          "height": "20px"
+        } 
+      />
 
       <!-- In This Issue -->
-      <in-this-issue-block
+      <!-- <in-this-issue-block
         date=date
         newsletter=newsletter
         section-name="In This Issue"
+      /> -->
+
+      <digital-edition-highlight-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        url-params=urlParams
+        limit=3
       />
 
     </div>
-
-    <!-- Promotion Slot 1 -->
+    
+    <!-- Promotion Slot 1
     <daily-block-advertisement
       date=date
       newsletter=newsletter
@@ -69,7 +90,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
       url-params=urlParams
-    />
+    /> -->
 
     <!-- footer -->
     <daily-footer />

--- a/tenants/all/templates/me-digital-edition.marko
+++ b/tenants/all/templates/me-digital-edition.marko
@@ -78,6 +78,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
         section-name="In This Issue"
         url-params=urlParams
         limit=3
+        dpm={ isDigital: isDigital }
       />
 
     </div>

--- a/tenants/all/templates/np-digital-edition.marko
+++ b/tenants/all/templates/np-digital-edition.marko
@@ -37,6 +37,13 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">
       <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
+      <digital-edition-overview-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      /> 
+      <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
       <div id="headers" style="background-color:#FFF;text-align: center; padding: 5px 0px; display: block; margin: 5px 0 5px; overflow: hidden; position: relative;">
 
         $ const adUnit = emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias });
@@ -50,18 +57,32 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
       </div>
 
-      <common-spacer-element />
+      <common-spacer-element 
+        style={
+          "font-size": "20px",
+          "line-height": "20px",
+          "height": "20px"
+        } 
+      />
 
-        <!-- In This Issue -->
-        <in-this-issue-block
-          date=date
-          newsletter=newsletter
-          section-name="In This Issue"
-        />
+      <!-- In This Issue -->
+      <!-- <in-this-issue-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+      /> -->
+
+      <digital-edition-highlight-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        url-params=urlParams
+        limit=3
+      />
 
     </div>
-
-    <!-- Promotion Slot 1 -->
+    
+    <!-- Promotion Slot 1
     <daily-block-advertisement
       date=date
       newsletter=newsletter
@@ -69,7 +90,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
       url-params=urlParams
-    />
+    /> -->
 
     <!-- footer -->
     <daily-footer />

--- a/tenants/all/templates/np-digital-edition.marko
+++ b/tenants/all/templates/np-digital-edition.marko
@@ -78,6 +78,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
         section-name="In This Issue"
         url-params=urlParams
         limit=3
+        dpm={ isDigital: isDigital }
       />
 
     </div>

--- a/tenants/all/templates/pf-digital-edition.marko
+++ b/tenants/all/templates/pf-digital-edition.marko
@@ -37,6 +37,13 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">
       <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
+      <digital-edition-overview-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      /> 
+      <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
       <div id="headers" style="background-color:#FFF;text-align: center; padding: 5px 0px; display: block; margin: 5px 0 5px; overflow: hidden; position: relative;">
 
         $ const adUnit = emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias });
@@ -50,15 +57,31 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
       </div>
 
-      <common-spacer-element />
+      <common-spacer-element 
+        style={
+          "font-size": "20px",
+          "line-height": "20px",
+          "height": "20px"
+        } 
+      />
 
       <!-- In This Issue -->
-      <in-this-issue-block
+      <!-- <in-this-issue-block
         date=date
         newsletter=newsletter
         section-name="In This Issue"
+      /> -->
+
+      <digital-edition-highlight-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        url-params=urlParams
+        limit=3
       />
 
+    </div>
+    
     <!-- Promotion Slot 1
     <daily-block-advertisement
       date=date
@@ -68,8 +91,6 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
       with-header=false
       url-params=urlParams
     /> -->
-
-    </div>
 
     <!-- footer -->
     <daily-footer />

--- a/tenants/all/templates/pf-digital-edition.marko
+++ b/tenants/all/templates/pf-digital-edition.marko
@@ -78,6 +78,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
         section-name="In This Issue"
         url-params=urlParams
         limit=3
+        dpm={ isDigital: isDigital }
       />
 
     </div>

--- a/tenants/all/templates/si-digital-edition.marko
+++ b/tenants/all/templates/si-digital-edition.marko
@@ -78,6 +78,7 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
         section-name="In This Issue"
         url-params=urlParams
         limit=3
+        dpm={ isDigital: isDigital }
       />
 
     </div>

--- a/tenants/all/templates/si-digital-edition.marko
+++ b/tenants/all/templates/si-digital-edition.marko
@@ -37,6 +37,13 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
     <div style="background-color: #FFFFFF;border-bottom: 2px solid #333;margin: 0px 5px; padding: 0px 5px;" id="main">
       <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
+      <digital-edition-overview-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      /> 
+      <!--[if (gte mso 9)|(lte IE 9)]><p style="font-size:1px; line-height:7px; height: 7px; margin:0px; padding: 0px;">&nbsp;</p><![endif]-->
       <div id="headers" style="background-color:#FFF;text-align: center; padding: 5px 0px; display: block; margin: 5px 0 5px; overflow: hidden; position: relative;">
 
         $ const adUnit = emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias });
@@ -50,19 +57,33 @@ $ const urlParams = buildUtmParams({ brand, date, isDigital });
 
       </div>
 
-      <common-spacer-element />
+      <common-spacer-element 
+        style={
+          "font-size": "20px",
+          "line-height": "20px",
+          "height": "20px"
+        } 
+      />
 
       <!-- In This Issue -->
-      <in-this-issue-block
+      <!-- <in-this-issue-block
         date=date
         newsletter=newsletter
         section-name="In This Issue"
+      /> -->
+
+      <digital-edition-highlight-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        url-params=urlParams
+        limit=3
       />
 
     </div>
-
-    <!-- Promotion Slot 1 -->
-    <!-- <daily-block-advertisement
+    
+    <!-- Promotion Slot 1
+    <daily-block-advertisement
       date=date
       newsletter=newsletter
       ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })


### PR DESCRIPTION
This is revising the structure of the digital edition email templates. I have created two new blocks. Issue Overview will take the place of the in-this-issue block and will now match styles from a standard item in the other newsletters. It has also been moved above the cover/ad row. And the new Highlight block will appear below that row and uses the same templates as a featured item (with hero image) from the daily newsletters. This second block is pulling from the second position of the same 'in-this-issue' position the Editors have already been using. So nothing has to change on the back end for this new setup. They are only planning on highlighting one article or theme per email, but this does support up to two promotion items (positions 2 and 3).

Since these use Promotions, I am disabling the DPM tracking on the links in the Highlight block, since we don't want them treated as advertising. We may decided to revisit this at some point, but for now, we will continue having only the display ad utilize any DPM tracking. More info on this in those commits.

**Previous Version:**
<img width="400" alt="digital-mag-before" src="https://user-images.githubusercontent.com/106970/167918410-9fd15417-13fd-446e-80dc-ff93d8e7d854.png">

**New Layout:** 
<img width="400" alt="Digital-mag-email-mockup-final" src="https://user-images.githubusercontent.com/106970/167918452-6e223341-150c-45df-8242-59aa157bf0f5.png">

@solocommand @brandonbk 