### PR TITLE
Strip Editorial content name of special characters for DPM comment LCV value

### DIFF
--- a/packages/common/components/dpm/content.marko
+++ b/packages/common/components/dpm/content.marko
@@ -47,7 +47,8 @@ $ const dpmEnabled = isDigital ? false : dpmConfig.enabled;
       get(node, "company.tasAdvertiserId") || "",
       node.id,
       position,
-      node.name,
+      // Strip the Editorial content name of "special characters"
+      node.name.replace(/[^a-zA-Z0-9 ]/g, ''),
     ].join("|");
     $ const dpm = {
       ln: (node.type === "product") ? companyName : authors,


### PR DESCRIPTION
Previously:
<img width="1796" alt="Screen Shot 2022-11-03 at 11 14 40 AM" src="https://user-images.githubusercontent.com/46794001/199775440-df2a1176-0bd2-4cf2-9a47-fdc44c0219c6.png">

After change:
<img width="1790" alt="Screen Shot 2022-11-03 at 11 13 57 AM" src="https://user-images.githubusercontent.com/46794001/199775493-af0f3b26-6cd0-4d58-8bfb-d3c4ab6171d5.png">
