### PR TITLE
AF Mar23 Product Launch

### DIFF
--- a/tenants/all/templates/blp-product-launch.marko
+++ b/tenants/all/templates/blp-product-launch.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/blp-logo-only-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/blp-product-launch.marko
+++ b/tenants/all/templates/blp-product-launch.marko
@@ -1,0 +1,73 @@
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../config/email-x";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date } = data;
+
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;font-family: Arial, Helvetica, sans-serif;font-size: 100%;padding: 0;background-color: #fff;">
+
+    <!--[if (gte mso 9)|(lte IE 9)]><table width="600" align="center" cellpadding="0" cellspacing="0" border="0" class="ieTableFix"><tr><td valign="top"><![endif]-->
+    <div class="wrapper" style="font-family: Trebuchet, Helvetica, Arial,sans-serif;max-width: 600px;font-size: 100%;margin: 0 auto;padding: 0 5px;">
+
+      <!-- View online, logos, dateline -->
+      <daily-header
+        name=newsletter.name
+        href=website.get("origin")
+        date=date
+        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+      />
+
+      <!-- In This Issue -->
+      <shared-intro-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      />
+
+      <common-spacer-element />
+
+      <!-- Headline -->
+      <daily-block-featured
+        date=date
+        newsletter=newsletter
+        section-name="Headline"
+        dpm={ startingPosition: 100 }
+        limit=1
+      />
+
+      <!-- Promotion Slot 1 -->
+      <!-- <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+      /> -->
+
+      <!-- Products -->
+      <daily-block-grid
+        date=date
+        newsletter=newsletter
+        section-name="Products"
+        dpm={ startingPosition: 200 }
+      />
+
+      <!-- footer -->
+      <daily-footer />
+
+    </div>
+    <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/all/templates/components/shared-intro-block.marko
+++ b/tenants/all/templates/components/shared-intro-block.marko
@@ -1,0 +1,63 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../../config/email-x";
+
+$ const { config } = out.global;
+$ const { date, newsletter, sectionName } = input;
+$ const limit = defaultValue(input.limit, 1);
+
+$ const headlineStylePlain = {
+  "font-size": "20px",
+  "line-height": "26px",
+  "margin": "0px 0px 3px 0px",
+  "padding": "0px 0px 3px 0px",
+  "color": "#000000",
+  "text-align": "left",
+  "font-family": "Helvetica,Arial,sans-serif",
+  "font-weight": "bold",
+};
+$ const headlineStyle = {
+  "margin": "0px",
+  "color": "#000",
+  "font-size": "20px",
+  "line-height": "27px",
+  "padding": "5px 5px 0px",
+  "background-color": "#FFF",
+  "text-align": "center",
+  "text-transform": "uppercase",
+  "font-weight": "normal",
+  "border-top": "2px solid #000",
+  "border-bottom": "2px solid #000",
+}
+$ const teaserStyle = {
+  "padding": "2px 0px 2px 0px",
+  "margin": "2px 0px 2px 2px",
+  "font-size": "15px",
+  "line-height": "22px",
+  "font-family": "arial,sans-serif",
+  "text-align": "left",
+  "color": "#333;",
+};
+
+<marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+  date: date.valueOf(),
+  newsletterId: newsletter.id,
+  sectionName,
+  limit,
+  queryFragment,
+}>
+  <common-spacer-element />
+  <!--[if (gte mso 9)|(lte IE 9)]><table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse;" class="ieTableFix"><tr><td valign="top"><![endif]-->
+  <div class="category" style="padding: 0px 0px 1px !important;">
+    <for|node| of=nodes>
+        <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
+        <div class="web" style="overflow: hidden; margin: 1px 0; padding: 1px 0; clear: both; background-color: #fff;">
+            <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } />
+            <marko-core-obj-text tag="p" class="abstract" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+        </div>
+        <!--[if (gte mso 9)|(lte IE 9)]> </td></tr></table><p class="ie" style="font-size: 1px; line-height: 10px; height: 10px; margin: 0px; padding: 0px; font-family: arial,sans-serif; text-align: left; color: #333; background-color: #FFFFFF; clear: both;">&nbsp;</p><![endif]-->
+    </for>
+  </div>
+  <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+</marko-web-query>

--- a/tenants/all/templates/ct-product-launch.marko
+++ b/tenants/all/templates/ct-product-launch.marko
@@ -1,0 +1,72 @@
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../config/email-x";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date } = data;
+
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;font-family: Arial, Helvetica, sans-serif;font-size: 100%;padding: 0;background-color: #fff;">
+
+    <!--[if (gte mso 9)|(lte IE 9)]><table width="600" align="center" cellpadding="0" cellspacing="0" border="0" class="ieTableFix"><tr><td valign="top"><![endif]-->
+    <div class="wrapper" style="font-family: Trebuchet, Helvetica, Arial,sans-serif;max-width: 600px;font-size: 100%;margin: 0 auto;padding: 0 5px;">
+
+      <!-- View online, logos, dateline -->
+      <daily-header
+        name=newsletter.name
+        href=website.get("origin")
+        date=date
+        image-src="/files/base/allured/all/image/static/newsletter/ct-product-roundup-header.png"
+      />
+
+      <!-- In This Issue -->
+      <in-this-issue-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+      />
+
+      <!-- Headline -->
+      <daily-block-featured
+        date=date
+        newsletter=newsletter
+        section-name="Headline"
+        dpm={ startingPosition: 100 }
+        limit=10
+      />
+
+      <common-spacer-element />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+      />
+
+      <!-- Products -->
+      <daily-block-grid
+        date=date
+        newsletter=newsletter
+        section-name="Products"
+        dpm={ startingPosition: 200 }
+      />
+
+      <!-- footer -->
+      <daily-footer />
+
+    </div>
+    <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/all/templates/ct-product-launch.marko
+++ b/tenants/all/templates/ct-product-launch.marko
@@ -24,15 +24,18 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ct-product-roundup-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
       />
 
       <!-- In This Issue -->
-      <in-this-issue-block
+      <shared-intro-block
         date=date
         newsletter=newsletter
         section-name="In This Issue"
+        limit=1
       />
+
+      <common-spacer-element />
 
       <!-- Headline -->
       <daily-block-featured
@@ -40,19 +43,17 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         newsletter=newsletter
         section-name="Headline"
         dpm={ startingPosition: 100 }
-        limit=10
+        limit=1
       />
 
-      <common-spacer-element />
-
       <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
+      <!-- <daily-block-advertisement
         date=date
         newsletter=newsletter
         ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
         dpm={ lc: "Editorial", position: 1 }
         with-header=false
-      />
+      /> -->
 
       <!-- Products -->
       <daily-block-grid

--- a/tenants/all/templates/gci-product-launch.marko
+++ b/tenants/all/templates/gci-product-launch.marko
@@ -1,0 +1,73 @@
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../config/email-x";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date } = data;
+
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;font-family: Arial, Helvetica, sans-serif;font-size: 100%;padding: 0;background-color: #fff;">
+
+    <!--[if (gte mso 9)|(lte IE 9)]><table width="600" align="center" cellpadding="0" cellspacing="0" border="0" class="ieTableFix"><tr><td valign="top"><![endif]-->
+    <div class="wrapper" style="font-family: Trebuchet, Helvetica, Arial,sans-serif;max-width: 600px;font-size: 100%;margin: 0 auto;padding: 0 5px;">
+
+      <!-- View online, logos, dateline -->
+      <daily-header
+        name=newsletter.name
+        href=website.get("origin")
+        date=date
+        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+      />
+
+      <!-- In This Issue -->
+      <shared-intro-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      />
+
+      <common-spacer-element />
+
+      <!-- Headline -->
+      <daily-block-featured
+        date=date
+        newsletter=newsletter
+        section-name="Headline"
+        dpm={ startingPosition: 100 }
+        limit=1
+      />
+
+      <!-- Promotion Slot 1 -->
+      <!-- <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+      /> -->
+
+      <!-- Products -->
+      <daily-block-grid
+        date=date
+        newsletter=newsletter
+        section-name="Products"
+        dpm={ startingPosition: 200 }
+      />
+
+      <!-- footer -->
+      <daily-footer />
+
+    </div>
+    <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/all/templates/gci-product-launch.marko
+++ b/tenants/all/templates/gci-product-launch.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/gci-logo-only-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/me-product-launch.marko
+++ b/tenants/all/templates/me-product-launch.marko
@@ -1,0 +1,73 @@
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../config/email-x";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date } = data;
+
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;font-family: Arial, Helvetica, sans-serif;font-size: 100%;padding: 0;background-color: #fff;">
+
+    <!--[if (gte mso 9)|(lte IE 9)]><table width="600" align="center" cellpadding="0" cellspacing="0" border="0" class="ieTableFix"><tr><td valign="top"><![endif]-->
+    <div class="wrapper" style="font-family: Trebuchet, Helvetica, Arial,sans-serif;max-width: 600px;font-size: 100%;margin: 0 auto;padding: 0 5px;">
+
+      <!-- View online, logos, dateline -->
+      <daily-header
+        name=newsletter.name
+        href=website.get("origin")
+        date=date
+        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+      />
+
+      <!-- In This Issue -->
+      <shared-intro-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      />
+
+      <common-spacer-element />
+
+      <!-- Headline -->
+      <daily-block-featured
+        date=date
+        newsletter=newsletter
+        section-name="Headline"
+        dpm={ startingPosition: 100 }
+        limit=1
+      />
+
+      <!-- Promotion Slot 1 -->
+      <!-- <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+      /> -->
+
+      <!-- Products -->
+      <daily-block-grid
+        date=date
+        newsletter=newsletter
+        section-name="Products"
+        dpm={ startingPosition: 200 }
+      />
+
+      <!-- footer -->
+      <daily-footer />
+
+    </div>
+    <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/all/templates/me-product-launch.marko
+++ b/tenants/all/templates/me-product-launch.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/me-logo-only-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/np-product-launch.marko
+++ b/tenants/all/templates/np-product-launch.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/np-logo-only-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/np-product-launch.marko
+++ b/tenants/all/templates/np-product-launch.marko
@@ -1,0 +1,73 @@
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../config/email-x";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date } = data;
+
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;font-family: Arial, Helvetica, sans-serif;font-size: 100%;padding: 0;background-color: #fff;">
+
+    <!--[if (gte mso 9)|(lte IE 9)]><table width="600" align="center" cellpadding="0" cellspacing="0" border="0" class="ieTableFix"><tr><td valign="top"><![endif]-->
+    <div class="wrapper" style="font-family: Trebuchet, Helvetica, Arial,sans-serif;max-width: 600px;font-size: 100%;margin: 0 auto;padding: 0 5px;">
+
+      <!-- View online, logos, dateline -->
+      <daily-header
+        name=newsletter.name
+        href=website.get("origin")
+        date=date
+        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+      />
+
+      <!-- In This Issue -->
+      <shared-intro-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      />
+
+      <common-spacer-element />
+
+      <!-- Headline -->
+      <daily-block-featured
+        date=date
+        newsletter=newsletter
+        section-name="Headline"
+        dpm={ startingPosition: 100 }
+        limit=1
+      />
+
+      <!-- Promotion Slot 1 -->
+      <!-- <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+      /> -->
+
+      <!-- Products -->
+      <daily-block-grid
+        date=date
+        newsletter=newsletter
+        section-name="Products"
+        dpm={ startingPosition: 200 }
+      />
+
+      <!-- footer -->
+      <daily-footer />
+
+    </div>
+    <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/all/templates/pf-product-launch.marko
+++ b/tenants/all/templates/pf-product-launch.marko
@@ -1,0 +1,73 @@
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../config/email-x";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date } = data;
+
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;font-family: Arial, Helvetica, sans-serif;font-size: 100%;padding: 0;background-color: #fff;">
+
+    <!--[if (gte mso 9)|(lte IE 9)]><table width="600" align="center" cellpadding="0" cellspacing="0" border="0" class="ieTableFix"><tr><td valign="top"><![endif]-->
+    <div class="wrapper" style="font-family: Trebuchet, Helvetica, Arial,sans-serif;max-width: 600px;font-size: 100%;margin: 0 auto;padding: 0 5px;">
+
+      <!-- View online, logos, dateline -->
+      <daily-header
+        name=newsletter.name
+        href=website.get("origin")
+        date=date
+        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+      />
+
+      <!-- In This Issue -->
+      <shared-intro-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      />
+
+      <common-spacer-element />
+
+      <!-- Headline -->
+      <daily-block-featured
+        date=date
+        newsletter=newsletter
+        section-name="Headline"
+        dpm={ startingPosition: 100 }
+        limit=1
+      />
+
+      <!-- Promotion Slot 1 -->
+      <!-- <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+      /> -->
+
+      <!-- Products -->
+      <daily-block-grid
+        date=date
+        newsletter=newsletter
+        section-name="Products"
+        dpm={ startingPosition: 200 }
+      />
+
+      <!-- footer -->
+      <daily-footer />
+
+    </div>
+    <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/all/templates/pf-product-launch.marko
+++ b/tenants/all/templates/pf-product-launch.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/pf-logo-only-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/si-product-launch.marko
+++ b/tenants/all/templates/si-product-launch.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/si-logo-only-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/si-product-launch.marko
+++ b/tenants/all/templates/si-product-launch.marko
@@ -1,0 +1,73 @@
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../config/email-x";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date } = data;
+
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;font-family: Arial, Helvetica, sans-serif;font-size: 100%;padding: 0;background-color: #fff;">
+
+    <!--[if (gte mso 9)|(lte IE 9)]><table width="600" align="center" cellpadding="0" cellspacing="0" border="0" class="ieTableFix"><tr><td valign="top"><![endif]-->
+    <div class="wrapper" style="font-family: Trebuchet, Helvetica, Arial,sans-serif;max-width: 600px;font-size: 100%;margin: 0 auto;padding: 0 5px;">
+
+      <!-- View online, logos, dateline -->
+      <daily-header
+        name=newsletter.name
+        href=website.get("origin")
+        date=date
+        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+      />
+
+      <!-- In This Issue -->
+      <shared-intro-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      />
+
+      <common-spacer-element />
+
+      <!-- Headline -->
+      <daily-block-featured
+        date=date
+        newsletter=newsletter
+        section-name="Headline"
+        dpm={ startingPosition: 100 }
+        limit=1
+      />
+
+      <!-- Promotion Slot 1 -->
+      <!-- <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+      /> -->
+
+      <!-- Products -->
+      <daily-block-grid
+        date=date
+        newsletter=newsletter
+        section-name="Products"
+        dpm={ startingPosition: 200 }
+      />
+
+      <!-- footer -->
+      <daily-footer />
+
+    </div>
+    <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+
+  </@body>
+</marko-newsletter-root>

--- a/tenants/all/templates/ws-product-launch.marko
+++ b/tenants/all/templates/ws-product-launch.marko
@@ -24,7 +24,7 @@ $ const blackBarText = "text-decoration: none !important; font-size: 10px; font-
         name=newsletter.name
         href=website.get("origin")
         date=date
-        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+        image-src="/files/base/allured/all/image/static/newsletter/ws-logo-only-header.png"
       />
 
       <!-- In This Issue -->

--- a/tenants/all/templates/ws-product-launch.marko
+++ b/tenants/all/templates/ws-product-launch.marko
@@ -1,0 +1,73 @@
+import queryFragment from "@allured-business-media/common/graphql/fragments/content-list";
+import emailX from "../config/email-x";
+
+$ const { website, config } = out.global;
+$ const { newsletter, date } = data;
+
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;font-family: Arial, Helvetica, sans-serif;font-size: 100%;padding: 0;background-color: #fff;">
+
+    <!--[if (gte mso 9)|(lte IE 9)]><table width="600" align="center" cellpadding="0" cellspacing="0" border="0" class="ieTableFix"><tr><td valign="top"><![endif]-->
+    <div class="wrapper" style="font-family: Trebuchet, Helvetica, Arial,sans-serif;max-width: 600px;font-size: 100%;margin: 0 auto;padding: 0 5px;">
+
+      <!-- View online, logos, dateline -->
+      <daily-header
+        name=newsletter.name
+        href=website.get("origin")
+        date=date
+        image-src="/files/base/allured/all/image/static/newsletter/ct-logo-only-header.png"
+      />
+
+      <!-- In This Issue -->
+      <shared-intro-block
+        date=date
+        newsletter=newsletter
+        section-name="In This Issue"
+        limit=1
+      />
+
+      <common-spacer-element />
+
+      <!-- Headline -->
+      <daily-block-featured
+        date=date
+        newsletter=newsletter
+        section-name="Headline"
+        dpm={ startingPosition: 100 }
+        limit=1
+      />
+
+      <!-- Promotion Slot 1 -->
+      <!-- <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+      /> -->
+
+      <!-- Products -->
+      <daily-block-grid
+        date=date
+        newsletter=newsletter
+        section-name="Products"
+        dpm={ startingPosition: 200 }
+      />
+
+      <!-- footer -->
+      <daily-footer />
+
+    </div>
+    <!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><![endif]-->
+
+  </@body>
+</marko-newsletter-root>


### PR DESCRIPTION
Setting up a new Product Launch template for each of the 8 brands. They were already set up in Base, and seem to be working fine locally. I still need to work on the omeda side, but I think this covers all the P1 stuff.
The new template is just a tweak to the Product Roundup template, so it shouldn't be too complicated. All of the new header images have also been uploaded to P1's S3 bucket already.
It's been a while since we added a new newsletter template, so please let me know if I missed anything. 
@jwade1327 