### PR TITLE
AF-Mar2024  Newsletter Changes

### DIFF
--- a/tenants/all/templates/blp-newsletter.marko
+++ b/tenants/all/templates/blp-newsletter.marko
@@ -54,15 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
 
       <daily-block-advertisement
         date=date
@@ -159,6 +150,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/components/daily-block-standard.marko
+++ b/tenants/all/templates/components/daily-block-standard.marko
@@ -8,7 +8,7 @@ $ const { config } = out.global;
 $ const { date, newsletter, sectionName } = input;
 
 $ const limit = defaultValue(input.limit, 10);
-$ const title = defaultValue(input.title, sectionName);
+$ const title = defaultValue(input.title, false);
 $ const withHero = defaultValue(input.withHero, true);
 $ const dpm = getAsObject(input, 'dpm');
 $ const urlParams = defaultValue(input.urlParams, false);
@@ -24,7 +24,9 @@ $ const urlParams = defaultValue(input.urlParams, false);
   <common-spacer-element />
   <!--[if (gte mso 9)|(lte IE 9)]><table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="category" style="padding: 0px 0px 1px;">
-    <h1 style="margin: 0px;font-size: 16px;line-height: 18px;text-align: left;letter-spacing:.5px;text-transform:uppercase;font-weight:normal;color:#FFFFFF;border-style: solid;border-width:5px 5px 4px;background-color: #FF9900;border-color: #FF9900; ">${title}</h1>
+    <if(title)>
+      <h1 style="margin: 0px;font-size: 16px;line-height: 18px;text-align: left;letter-spacing:.5px;text-transform:uppercase;font-weight:normal;color:#FFFFFF;border-style: solid;border-width:5px 5px 4px;background-color: #FF9900;border-color: #FF9900; ">${title}</h1>
+    </if>
     <if(withHero)>
       $ const heroNode = nodes.slice(0, 1)[0];
       $ const listNodes = nodes.slice(1);

--- a/tenants/all/templates/ct-newsletter-am.marko
+++ b/tenants/all/templates/ct-newsletter-am.marko
@@ -105,6 +105,7 @@ $ const urlParams = buildUtmParams({ brand, date });
         date=date
         newsletter=newsletter
         section-name="Archived"
+        title="Archived"
         dpm={ startingPosition: 400 }
         url-params=urlParams
       />

--- a/tenants/all/templates/ct-newsletter-am.marko
+++ b/tenants/all/templates/ct-newsletter-am.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         newsletter=newsletter
@@ -127,6 +117,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/ct-newsletter-pm.marko
+++ b/tenants/all/templates/ct-newsletter-pm.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         newsletter=newsletter
@@ -127,6 +117,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/ct-special-edition.marko
+++ b/tenants/all/templates/ct-special-edition.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         newsletter=newsletter
@@ -123,6 +113,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         section-name="Ad Slot 1"
@@ -185,6 +175,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         name="Partnered With Green Spa Network"
         href="https://gsnplanet.org/"
         image-src="/files/base/allured/all/image/static/gsn_logo.png"
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/gci-breaking-news.marko
+++ b/tenants/all/templates/gci-breaking-news.marko
@@ -54,6 +54,14 @@ $ const urlParams = buildUtmParams({ brand, date });
 
     <common-spacer-element />
 
+    <daily-block-advertisement
+      date=date
+      newsletter=newsletter
+      ad-unit=emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias })
+      placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-1`)
+      dpm={ position: 1 }
+    />
+
     <!-- Promotion Slot 1 -->
     <daily-block-advertisement
       date=date
@@ -62,14 +70,6 @@ $ const urlParams = buildUtmParams({ brand, date });
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
       url-params=urlParams
-    />
-
-    <daily-block-advertisement
-      date=date
-      newsletter=newsletter
-      ad-unit=emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias })
-      placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-1`)
-      dpm={ position: 1 }
     />
 
     <!-- footer -->

--- a/tenants/all/templates/gci-newsletter-am.marko
+++ b/tenants/all/templates/gci-newsletter-am.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         newsletter=newsletter
@@ -127,6 +117,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/gci-newsletter-pm.marko
+++ b/tenants/all/templates/gci-newsletter-pm.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         newsletter=newsletter
@@ -127,6 +117,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/gci-special-edition.marko
+++ b/tenants/all/templates/gci-special-edition.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         newsletter=newsletter
@@ -123,6 +113,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/me-newsletter.marko
+++ b/tenants/all/templates/me-newsletter.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         section-name="Ad Slot 1"
@@ -159,6 +149,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/np-newsletter.marko
+++ b/tenants/all/templates/np-newsletter.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         section-name="Ad Slot 1"
@@ -196,6 +186,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/pf-breaking-news.marko
+++ b/tenants/all/templates/pf-breaking-news.marko
@@ -54,6 +54,14 @@ $ const urlParams = buildUtmParams({ brand, date });
 
     <common-spacer-element />
 
+    <daily-block-advertisement
+      date=date
+      newsletter=newsletter
+      ad-unit=emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias })
+      placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-1`)
+      dpm={ position: 1 }
+    />
+
     <!-- Promotion Slot 1 -->
     <daily-block-advertisement
       date=date
@@ -62,14 +70,6 @@ $ const urlParams = buildUtmParams({ brand, date });
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
       url-params=urlParams
-    />
-
-    <daily-block-advertisement
-      date=date
-      newsletter=newsletter
-      ad-unit=emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias })
-      placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-1`)
-      dpm={ position: 1 }
     />
 
     <!-- footer -->

--- a/tenants/all/templates/pf-newsletter.marko
+++ b/tenants/all/templates/pf-newsletter.marko
@@ -67,6 +67,7 @@ $ const urlParams = buildUtmParams({ brand, date });
         date=date
         newsletter=newsletter
         section-name="Flavor"
+        title="Flavor"
         dpm={ startingPosition: 200 }
         url-params=urlParams
       />
@@ -86,6 +87,7 @@ $ const urlParams = buildUtmParams({ brand, date });
         date=date
         newsletter=newsletter
         section-name="Fragrance"
+        title="Fragrance"
         dpm={ startingPosition: 300 }
         url-params=urlParams
       />
@@ -105,6 +107,7 @@ $ const urlParams = buildUtmParams({ brand, date });
         date=date
         newsletter=newsletter
         section-name="In Case You Missed It"
+        title="In Case You Missed It"
         dpm={ startingPosition: 400 }
         url-params=urlParams
       />

--- a/tenants/all/templates/pf-newsletter.marko
+++ b/tenants/all/templates/pf-newsletter.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         newsletter=newsletter
@@ -127,6 +117,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/pf-special-edition.marko
+++ b/tenants/all/templates/pf-special-edition.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         newsletter=newsletter
@@ -123,6 +113,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->

--- a/tenants/all/templates/si-breaking-news.marko
+++ b/tenants/all/templates/si-breaking-news.marko
@@ -54,6 +54,14 @@ $ const urlParams = buildUtmParams({ brand, date });
 
     <common-spacer-element />
 
+    <daily-block-advertisement
+      date=date
+      newsletter=newsletter
+      ad-unit=emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias })
+      placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-1`)
+      dpm={ position: 1 }
+    />
+
     <!-- Promotion Slot 1 -->
     <daily-block-advertisement
       date=date
@@ -62,14 +70,6 @@ $ const urlParams = buildUtmParams({ brand, date });
       dpm={ lc: "Editorial", position: 1 }
       with-header=false
       url-params=urlParams
-    />
-
-    <daily-block-advertisement
-      date=date
-      newsletter=newsletter
-      ad-unit=emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias })
-      placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-1`)
-      dpm={ position: 1 }
     />
 
     <!-- footer -->

--- a/tenants/all/templates/si-newsletter.marko
+++ b/tenants/all/templates/si-newsletter.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         newsletter=newsletter
@@ -136,6 +126,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         newsletter=newsletter
         section-name="Partners"
         dpm={ startingPosition: 500 }
+        url-params=urlParams
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
         url-params=urlParams
       />
 

--- a/tenants/all/templates/si-special-edition.marko
+++ b/tenants/all/templates/si-special-edition.marko
@@ -54,16 +54,6 @@ $ const urlParams = buildUtmParams({ brand, date });
 
       <common-spacer-element />
 
-      <!-- Promotion Slot 1 -->
-      <daily-block-advertisement
-        date=date
-        newsletter=newsletter
-        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
-        dpm={ lc: "Editorial", position: 1 }
-        with-header=false
-        url-params=urlParams
-      />
-
       <daily-block-advertisement
         date=date
         newsletter=newsletter
@@ -124,6 +114,16 @@ $ const urlParams = buildUtmParams({ brand, date });
         ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
         placement-id=get(nativeX, `placements.${newsletter.alias}.ad-slot-4`)
         dpm={ position: 4 }
+      />
+
+      <!-- Promotion Slot 1 -->
+      <daily-block-advertisement
+        date=date
+        newsletter=newsletter
+        ad-unit=emailX.getAdUnit({ name: "promotion-slot-1", alias: newsletter.alias })
+        dpm={ lc: "Editorial", position: 1 }
+        with-header=false
+        url-params=urlParams
       />
 
       <!-- footer -->


### PR DESCRIPTION
Some adjustments to help with Editorial workflow refinements. 
Moving our house ad Promotion Slot 1 to the end of the newsletter to place higher priority on content and paid ads.
Also removing the orange section title bars from almost all newsletter sections. The section titles are remaining for the PF daily newsletter sections and one 'Archived' section in C&T's daily newsletter. 