### PR TITLE
AF Mar2024 2nd NL update

### DIFF
--- a/tenants/all/templates/blp-newsletter.marko
+++ b/tenants/all/templates/blp-newsletter.marko
@@ -89,7 +89,6 @@ $ const urlParams = buildUtmParams({ brand, date });
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
         url-params=urlParams
       />

--- a/tenants/all/templates/components/daily-block-standard.marko
+++ b/tenants/all/templates/components/daily-block-standard.marko
@@ -9,7 +9,7 @@ $ const { date, newsletter, sectionName } = input;
 
 $ const limit = defaultValue(input.limit, 10);
 $ const title = defaultValue(input.title, false);
-$ const withHero = defaultValue(input.withHero, true);
+$ const withHero = defaultValue(input.withHero, false);
 $ const dpm = getAsObject(input, 'dpm');
 $ const urlParams = defaultValue(input.urlParams, false);
 

--- a/tenants/all/templates/ct-newsletter-am.marko
+++ b/tenants/all/templates/ct-newsletter-am.marko
@@ -106,6 +106,7 @@ $ const urlParams = buildUtmParams({ brand, date });
         newsletter=newsletter
         section-name="Archived"
         title="Archived"
+        with-hero=true
         dpm={ startingPosition: 400 }
         url-params=urlParams
       />

--- a/tenants/all/templates/ds-newsletter.marko
+++ b/tenants/all/templates/ds-newsletter.marko
@@ -88,7 +88,6 @@ $ const urlParams = buildUtmParams({ brand, date });
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
         url-params=urlParams
       />

--- a/tenants/all/templates/me-newsletter.marko
+++ b/tenants/all/templates/me-newsletter.marko
@@ -88,7 +88,6 @@ $ const urlParams = buildUtmParams({ brand, date });
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
         url-params=urlParams
       />

--- a/tenants/all/templates/np-newsletter.marko
+++ b/tenants/all/templates/np-newsletter.marko
@@ -88,7 +88,6 @@ $ const urlParams = buildUtmParams({ brand, date });
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
         url-params=urlParams
       />

--- a/tenants/all/templates/pf-newsletter.marko
+++ b/tenants/all/templates/pf-newsletter.marko
@@ -68,6 +68,7 @@ $ const urlParams = buildUtmParams({ brand, date });
         newsletter=newsletter
         section-name="Flavor"
         title="Flavor"
+        with-hero=true
         dpm={ startingPosition: 200 }
         url-params=urlParams
       />
@@ -88,6 +89,7 @@ $ const urlParams = buildUtmParams({ brand, date });
         newsletter=newsletter
         section-name="Fragrance"
         title="Fragrance"
+        with-hero=true
         dpm={ startingPosition: 300 }
         url-params=urlParams
       />
@@ -108,6 +110,7 @@ $ const urlParams = buildUtmParams({ brand, date });
         newsletter=newsletter
         section-name="In Case You Missed It"
         title="In Case You Missed It"
+        with-hero=true
         dpm={ startingPosition: 400 }
         url-params=urlParams
       />

--- a/tenants/all/templates/si-newsletter.marko
+++ b/tenants/all/templates/si-newsletter.marko
@@ -86,7 +86,6 @@ $ const urlParams = buildUtmParams({ brand, date });
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
         url-params=urlParams
       />

--- a/tenants/all/templates/si-special-edition.marko
+++ b/tenants/all/templates/si-special-edition.marko
@@ -86,7 +86,6 @@ $ const urlParams = buildUtmParams({ brand, date });
         date=date
         newsletter=newsletter
         section-name="New Products"
-        with-hero=false
         dpm={ startingPosition: 300 }
         url-params=urlParams
       />


### PR DESCRIPTION
Small update based on feedback from the team after the last batch of changes. Hero images need to be turned off by default on all sections that had their orange title bars removed. 
Some sections already has a bypass in place, so I made that the default, removed those (now redundant) bypasses and added exceptions for the 4 sections that needed to keep their hero images. 