### PR TITLE
AF-Sep2024-DigitalEditionLinks

### DIFF
--- a/packages/common/graphql/fragments/content-list.js
+++ b/packages/common/graphql/fragments/content-list.js
@@ -7,6 +7,7 @@ fragment NewsletterContentListFragment on Content {
   type
   name(input: { mutation: Email })
   teaser(input: { mutation: Email, useFallback: false, maxLength: null })
+  digitalEditionUrl: customAttribute(input: { path: "digitalEditionUrl" })
   primaryImage {
     id
     src

--- a/tenants/all/templates/components/daily-element-content-hero.marko
+++ b/tenants/all/templates/components/daily-element-content-hero.marko
@@ -5,6 +5,7 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 $ const urlParams = defaultValue(input.urlParams, {});
 $ const node = getAsObject(input, "node");
 $ const labels = getAsArray(input, "node.labels");
+$ const isDigital = get(input, "dpm.isDigital") || false;
 
 $ const imgStyles = {
   "border": 0,
@@ -89,13 +90,14 @@ $ const bylineStyle = {
 };
 $ const authors = getAsArray(node, "authors.edges").map(edge => get(edge, "node.name"));
 $ const byline = node.byline || authors.join(', ');
+$ const itemUrl = (node.digitalEditionUrl && isDigital) ? node.digitalEditionUrl : node.siteContext.url
 
 <if(node)>
 
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="web" style="overflow: hidden; margin: 5px 0; padding: 5px 0; clear: both; background-color: #fff;">
     <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } >
-      <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: headlineLinkStyle }>
+      <@link href=buildUrl({ url: itemUrl, params: urlParams }) target="_blank" attrs={ style: headlineLinkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>
@@ -115,7 +117,7 @@ $ const byline = node.byline || authors.join(', ');
         class="main"
         attrs={ border: 0, width: 600, align: "center", vspace: 5, style: imgStyles }
       >
-        <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: imgLinkStyles }>
+        <@link href=buildUrl({ url: itemUrl, params: urlParams }) target="_blank" attrs={ style: imgLinkStyles }>
           <@after>
             <common-dpm-content node=node dpm=input.dpm />
           </@after>
@@ -130,7 +132,7 @@ $ const byline = node.byline || authors.join(', ');
     <marko-core-obj-text tag="p" class="abstract" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
 
     <marko-core-text tag="p" value="Read More →" attrs={ style: readMoreStyle }>
-      <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: linkStyle }>
+      <@link href=buildUrl({ url: itemUrl, params: urlParams }) target="_blank" attrs={ style: linkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>

--- a/tenants/all/templates/components/daily-element-content-standard.marko
+++ b/tenants/all/templates/components/daily-element-content-standard.marko
@@ -6,6 +6,7 @@ $ const urlParams = defaultValue(input.urlParams, {});
 
 $ const node = getAsObject(input, "node");
 $ const labels = getAsArray(input, "node.labels");
+$ const isDigital = get(input, "dpm.isDigital") || false;
 
 $ const linkStyle = {
   "color": "#06f",
@@ -73,6 +74,7 @@ $ const bylineStyle = {
 };
 $ const authors = getAsArray(node, "authors.edges").map(edge => get(edge, "node.name"));
 $ const byline = node.byline || authors.join(', ');
+$ const itemUrl = (node.digitalEditionUrl && isDigital) ? node.digitalEditionUrl : node.siteContext.url
 
 <if(labels && labels.includes("Sponsored"))>
   <daily-element-content-sponsored node=node dpm=input.dpm url-params=urlParams />
@@ -82,7 +84,7 @@ $ const byline = node.byline || authors.join(', ');
   <!--[if (gte mso 9)|(lte IE 9)]> <table width="600" bgcolor="#FFFFFF" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#FFFFFF;" class="ieTableFix"><tr><td valign="top"><![endif]-->
   <div class="web" style="overflow: hidden; margin: 5px 0; padding: 5px 0; clear: both; background-color: #fff;">
     <marko-core-obj-text obj=node tag="h2" field="name" html=true attrs={ style: headlineStyle } >
-      <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: headlineLinkStyle }>
+      <@link href=buildUrl({ url: itemUrl, params: urlParams }) target="_blank" attrs={ style: headlineLinkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>
@@ -96,7 +98,7 @@ $ const byline = node.byline || authors.join(', ');
     <marko-core-obj-text tag="p" class="abstract" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
 
     <marko-core-text tag="p" value="Read More →" attrs={ style: readMoreStyle }>
-      <@link href=buildUrl({ url: node.siteContext.url, params: urlParams }) target="_blank" attrs={ style: linkStyle }>
+      <@link href=buildUrl({ url: itemUrl, params: urlParams }) target="_blank" attrs={ style: linkStyle }>
         <@after>
           <common-dpm-content node=node dpm=input.dpm />
         </@after>


### PR DESCRIPTION
Digital Edition Email items will link directly to the Digital Edition URLs (only applied to Digital Edition Newsletters) 
This change will allow Editors to schedule normal content items to the Digital Edition Email Newsletters and have them displayed as highlighted items, but link directly to the digital edition link instead of their website urls. This will allow them to not have to create so many near-duplicate Promotion items for each one they want to highlight in the newsletters.
![Digital_Edition_Email_Links](https://github.com/user-attachments/assets/1cdd807b-1fb2-47ec-9443-8f6c55de1226)
