### PR TITLE
AF-Sept2024-NativeTextAdFix

### DIFF
--- a/tenants/all/templates/components/daily-block-native-ad.marko
+++ b/tenants/all/templates/components/daily-block-native-ad.marko
@@ -76,6 +76,7 @@ $ const linkAttrs = {
   style: linkStyle,
 }
 
+<!--[if (gte mso 9)|(lte IE 9)]><table width="600" bgcolor="#E5E5E5" align="center" cellpadding="0" cellspacing="0" border="0" style="margin:0px; padding:0px; border-collapse:collapse; background-color:#E5E5E5;" class="ieTableFix"><tr><td valign="top"><![endif]-->
 <div class="banner" style="margin:5px auto; padding:3px 0px 10px;min-width:300px !important; text-align:center; clear:both; overflow:hidden; background-color:#E5E5E5; background:#e5e5e5 linear-gradient(to right, #fff 0%, #e5e5e5 15%, #e5e5e5 85%, #fff 100%); border-top:1px solid #ddd; border-bottom:1px solid #ddd;">
   <h5 style="font-size:9px; line-height:15px; margin:0px auto; padding:6px 0px 1px 0px; text-align:center; font-weight:normal; letter-spacing:1px; color:#999999; font-family:Helvetica,Arial,sans-serif;">ADVERTISEMENT</h5>
   <div class="wrapper" style="font-family:Helvetica,Arial,sans-serif;max-width: 600px;font-size: 100%;margin: 0 auto;padding: 0 5px;">
@@ -141,3 +142,4 @@ $ const linkAttrs = {
     <!-- End of More Link -->
   </div>
 </div>
+<!--[if (gte mso 9)|(lte IE 9)]></td></tr></table><p class="ie" style="font-size: 1px; line-height: 15px; height: 15px; margin: 0px; padding: 0px; font-family: arial,sans-serif; text-align: left; color: #333; background-color: #FFFFFF; clear: both;">&nbsp;</p><![endif]-->


### PR DESCRIPTION
Reapplying the Outlook-safe Text Ad Wrapper.
DPP-6301
I'm not sure how this was cut from the templates or was simply omitted during our initial conversion, but this wasn't reported to us until this week. It's possible that recent updates to Outlook reintroduced the bug that requires this special fix, or simply went unnoticed/unreported by all of our Outlook users. I also don't think it was caused by the recent switch to Mindful Ads.
Either way, this is the same wrapper used on display ads, so it should be well tested and seems to fix the issue. 
Before:
![before-outlook-bug](https://github.com/user-attachments/assets/fec077ff-8c8d-473e-9074-455ccb043f1c)

After:
<img width="954" alt="after-outlook-with-fix" src="https://github.com/user-attachments/assets/67a19e17-18d8-4e59-998e-cf482b5e4b16">

@jwade1327 